### PR TITLE
CMakeLists.txt changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required(VERSION 3.6)
+﻿cmake_minimum_required(VERSION 3.8)
 
 project(magic_enum VERSION "0.5.0" LANGUAGES CXX)
 
@@ -20,10 +20,11 @@ if(MAGIC_ENUM_OPT_BUILD_TESTS)
     add_subdirectory(test)
 endif()
 
-include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
 target_include_directories(${PROJECT_NAME}
         INTERFACE
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -34,16 +35,14 @@ write_basic_package_version_file(${PROJECT_NAME}ConfigVersion.cmake
         COMPATIBILITY AnyNewerVersion)
 
 install(TARGETS ${PROJECT_NAME}
-        EXPORT ${PROJECT_NAME}Targets
-        PUBLIC_HEADER DESTINATION include
-        INCLUDES DESTINATION include)
+        EXPORT ${PROJECT_NAME}Config)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
         DESTINATION lib/cmake/${PROJECT_NAME})
 
-install(EXPORT ${PROJECT_NAME}Targets
+install(EXPORT ${PROJECT_NAME}Config
         NAMESPACE ${PROJECT_NAME}::
         DESTINATION lib/cmake/${PROJECT_NAME})
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include
-        DESTINATION include)
+        DESTINATION .)


### PR DESCRIPTION
Bug Fixes:
* Currently can't use `find_package` as CMake is looking for `Config`not `Targets`
* Currently `magic_enum.hpp` is being installed to `include/include/magic_enum.hpp`

Additions/Removal:
* Added an alias to support using magic_enum via `add_subdirectory`
* Added `cxx_std_17` compile feature which requires 3.8 hence the change there
* Removed `GNUInstallDirs` since it wasn't being used
* Removed `PUBLIC_HEADER` and `INCLUDES DESTINATION` from the target install command as they are redundant.