### PR TITLE
Fix regression of enum_cast<>() when used with refs (EnumT& vs EnumT)

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -437,7 +437,7 @@ template <typename E>
 // Obtains enum value from integer value.
 // Returns std::optional with enum value.
 template <typename E>
-[[nodiscard]] constexpr auto enum_cast(std::underlying_type_t<E> value) noexcept -> detail::enable_if_enum_t<E, std::optional<std::decay_t<E>>> {
+[[nodiscard]] constexpr auto enum_cast(std::underlying_type_t<std::decay_t<E>> value) noexcept -> detail::enable_if_enum_t<std::decay_t<E>, std::optional<std::decay_t<E>>> {
   using D = std::decay_t<E>;
 
   if (enum_traits<D>::index(static_cast<D>(value)) != -1) {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -86,6 +86,7 @@ TEST_CASE("enum_cast") {
     constexpr auto cr = enum_cast<Color>(-12);
     REQUIRE(cr.value() == Color::RED);
     REQUIRE(enum_cast<Color>(7).value() == Color::GREEN);
+    REQUIRE(enum_cast<Color&>(7).value() == Color::GREEN);
     REQUIRE(enum_cast<Color>((int)cm[2]).value() == Color::BLUE);
     REQUIRE_FALSE(enum_cast<Color>(0).has_value());
 


### PR DESCRIPTION
Watered-down/Min-repro of real use-case:
```C++
enum class MyEnum
{
    A,
    B,
    C,
};

int main()
{
    MyEnum a = MyEnum::A;
    auto& type = a;
    auto t = magic_enum::enum_cast<decltype(type)>(0);

    assert(t == MyEnum::A);

    return 0;
}
```

This used to work with 0.5, but doesn't work with 0.6.1.

- Despite the repetition, did not specify `D = std::decay_t<E>` as a template parameter because this opens the possibility for users manually specifying the second parameter.
- Added a regression test for it. Not sure if it is too obscure?