### PR TITLE
improve compiler version check

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from conans import ConanFile
+from conans import ConanFile, tools
 from conans.errors import ConanInvalidConfiguration
 
 class MagicEnumConan(ConanFile):
@@ -29,7 +29,7 @@ class MagicEnumConan(ConanFile):
     @property
     def supported_compiler(self):
         compiler = str(self.settings.compiler)
-        version = str(self.settings.compiler.version)
+        version = tools.Version(self.settings.compiler.version)
         if compiler == "Visual Studio" and version >= "15":
             return True
         if compiler == "gcc" and version >= "9":


### PR DESCRIPTION
Hello

The compiler version check shouldn't use string comparison.
This causes problems with clang 10 and 11.

```
$ conan create . pck/stable -s compiler=clang -s compiler.version=10 -s compiler.libcxx=libc++
...
ERROR: magic_enum/0.6.4@pck/stable: Invalid configuration: magic_enum: Unsupported compiler (https://github.com/Neargye/magic_enum#compiler-compatibility).
```

Thank you for sharing your work.