### PR TITLE
 Introduce contains_value()

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Header-only C++17 library provides static reflection for enums, work with any en
 * `enum_names` obtains string enum name sequence.
 * `enum_entries` obtains pair (value enum, string enum name) sequence.
 * `enum_index` obtains index in enum value sequence from enum value.
+* `contains_value` checks whether enum contains such value
 * `is_unscoped_enum` checks whether type is an [Unscoped enumeration](https://en.cppreference.com/w/cpp/language/enum#Unscoped_enumeration).
 * `is_scoped_enum` checks whether type is an [Scoped enumeration](https://en.cppreference.com/w/cpp/language/enum#Scoped_enumerations).
 * `underlying_type` improved UB-free "SFINAE-friendly" [std::underlying_type](https://en.cppreference.com/w/cpp/types/underlying_type).

--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -490,7 +490,7 @@ template <typename E>
   return std::nullopt; // Value out of range.
 }
 
-// Returns true if enum contains enumerator with such value and false otherwise
+// Checks whether enum contains enumerator with such value
 template <typename E>
 [[nodiscard]] constexpr auto contains_value(underlying_type_t<E> value) noexcept -> detail::enable_if_enum_t<E, bool> {
   return enum_traits<E>::index(value) != -1;

--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -490,6 +490,12 @@ template <typename E>
   return std::nullopt; // Value out of range.
 }
 
+// Returns true if enum contains enumerator with such value and false otherwise
+template <typename E>
+[[nodiscard]] constexpr auto contains_value(underlying_type_t<E> value) noexcept -> detail::enable_if_enum_t<E, bool> {
+  return enum_traits<E>::index(value) != -1;
+}
+
 // Returns enum value at specified index.
 // No bounds checking is performed: the behavior is undefined if index >= number of enum values.
 template <typename E>

--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -359,18 +359,22 @@ struct enum_traits<E, true> {
     return static_cast<U>(value) >= static_cast<U>(reflected_min_v<E>) && static_cast<U>(value) <= static_cast<U>(reflected_max_v<E>);
   }
 
-  [[nodiscard]] static constexpr int index(E value) noexcept {
-    if (static_cast<U>(value) >= static_cast<U>(min_v<E>) && static_cast<U>(value) <= static_cast<U>(max_v<E>)) {
+  [[nodiscard]] static constexpr int index(underlying_type value) noexcept {
+    if (value >= min_v<E> && value <= max_v<E>) {
       if constexpr (is_sparse) {
-        if (const auto i = indexes[static_cast<U>(value) - min_v<E>]; i != invalid_index_v<E>) {
+        if (const auto i = indexes[value - min_v<E>]; i != invalid_index_v<E>) {
           return i;
         }
       } else {
-        return static_cast<U>(value) - min_v<E>;
+        return value - min_v<E>;
       }
     }
 
     return -1; // Value out of range.
+  }
+
+  [[nodiscard]] static constexpr int index(E value) noexcept {
+      return index(static_cast<U>(value));
   }
 
   [[nodiscard]] static constexpr E value(std::size_t index) noexcept {

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -176,6 +176,38 @@ TEST_CASE("enum_index") {
   REQUIRE_FALSE(enum_index(static_cast<number>(0)).has_value());
 }
 
+TEST_CASE("contains_value") {
+  REQUIRE(contains_value<Color>(-12));
+  REQUIRE(contains_value<Color>(7));
+  REQUIRE(contains_value<Color>(15));
+  REQUIRE_FALSE(contains_value<Color>(42));
+  REQUIRE_FALSE(contains_value<Color>(-120));
+  REQUIRE_FALSE(contains_value<Color>(0));
+
+  constexpr auto no = enum_integer(Numbers::one);
+  REQUIRE(contains_value<Numbers>(no));
+  REQUIRE(contains_value<Numbers>(enum_integer(Numbers::two)));
+  REQUIRE(contains_value<Numbers>(enum_integer(Numbers::three)));
+  REQUIRE_FALSE(contains_value<Numbers>(enum_integer(Numbers::many)));
+
+  constexpr auto dr = enum_integer(Directions::Right);
+  REQUIRE(contains_value<Directions&>(dr));
+  REQUIRE(contains_value<Directions>(Directions::Down));
+  REQUIRE(contains_value<Directions>(Directions::Up));
+  REQUIRE_FALSE(contains_value<Directions>(static_cast<Directions>(0)));
+
+  constexpr auto nt = contains_value<number>(number::three);
+  REQUIRE(contains_value<number>(number::one));
+  REQUIRE(contains_value<number>(100));
+  REQUIRE(contains_value<number>(200));
+  REQUIRE(contains_value<number>(300));
+  REQUIRE(contains_value<number>(number::two));
+  REQUIRE(nt);
+  REQUIRE_FALSE(contains_value<number>(number::four));
+  REQUIRE_FALSE(contains_value<number>(111));
+  REQUIRE_FALSE(contains_value<number>(0));
+}
+
 TEST_CASE("enum_value") {
   constexpr auto cr = enum_value<Color>(0);
   REQUIRE(cr == Color::RED);


### PR DESCRIPTION
**Why**? This is useful for validation. In some cases, we receive some numeric value from outside our program (it may be some serialization library or REST API), this often requires validation of value. 

**Why not use enum_index()**? There are two reasons. 

First, the name of this function has little different meaning and the code below is a little confused:
```cpp
auto has_value = enum_index(enum_value).has_value();
```
I think, this code is more readable:
```cpp
auto has_value = contains_value<E>(value);
```
The second reason is that we need an enum instance, but in these cases, we usually have a raw data or an integral value, so we need to use static_cast<E>(value), but this makes user code harder to read and requires an explicitly defined underlying type because otherwise cast is causes undefined behavior

**About naming**. I'm not sure if this is the best name for this function. It can be renamed to has_value() or enum_has_value() (since this library prefers naming starting with enum_ )

**About implementation**. I changed enum_traits::index() to avoid undefined behavior described above, so now there are two overloads of this function. The first accepts value of the underlying type and is implemented as before.
The second just casts enumerator to the underlying type (casting to the underlying type from enum is safe unlike casting to enum from the underlying type) and calls first overloading.
Another nice change is that there is no more need for many casts to underlying type.
Maybe it wasn’t worth do two overloads in enum_traits, but I don’t know how to do it better.
