### PR TITLE
fix: Include header for std::string

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -47,6 +47,9 @@
 #if !defined(MAGIC_ENUM_USING_ALIAS_OPTIONAL)
 #include <optional>
 #endif
+#if !defined(MAGIC_ENUM_USING_ALIAS_STRING)
+#include <string>
+#endif
 #if !defined(MAGIC_ENUM_USING_ALIAS_STRING_VIEW)
 #include <string_view>
 #endif


### PR DESCRIPTION
The `enum_name` function depends on a complete string type.