### PR TITLE
Add MAGIC_ENUM_OPT_INSTALL option in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 
 option(MAGIC_ENUM_OPT_BUILD_EXAMPLES "Build magic_enum examples" ${IS_TOPLEVEL_PROJECT})
 option(MAGIC_ENUM_OPT_BUILD_TESTS "Build and perform magic_enum tests" ${IS_TOPLEVEL_PROJECT})
+option(MAGIC_ENUM_OPT_INSTALL "Generate and install magic_enum target" ON)
 
 if(MAGIC_ENUM_OPT_BUILD_EXAMPLES)
     add_subdirectory(example)
@@ -33,15 +34,17 @@ write_basic_package_version_file(${PROJECT_NAME}ConfigVersion.cmake
         VERSION ${PROJECT_VERSION}
         COMPATIBILITY AnyNewerVersion)
 
-install(TARGETS ${PROJECT_NAME}
-        EXPORT ${PROJECT_NAME}Config)
+if(MAGIC_ENUM_OPT_INSTALL)
+    install(TARGETS ${PROJECT_NAME}
+            EXPORT ${PROJECT_NAME}Config)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-        DESTINATION lib/cmake/${PROJECT_NAME})
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+            DESTINATION lib/cmake/${PROJECT_NAME})
 
-install(EXPORT ${PROJECT_NAME}Config
-        NAMESPACE ${PROJECT_NAME}::
-        DESTINATION lib/cmake/${PROJECT_NAME})
+    install(EXPORT ${PROJECT_NAME}Config
+            NAMESPACE ${PROJECT_NAME}::
+            DESTINATION lib/cmake/${PROJECT_NAME})
 
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include
-        DESTINATION .)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include
+            DESTINATION .)
+endif()


### PR DESCRIPTION
Hello,

Thank you for this library.

May I contribute by adding this option which allows to skip install target. This is useful which can be useful when
vendoring magic_enum.

Have a nice day.