### PR TITLE
Add support for bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+
+### Bazel build artifacts ###
+bazel-*

--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,4 @@ CTestTestfile.cmake
 _deps
 
 ### Bazel build artifacts ###
-bazel-*
+/bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,56 @@
+licenses(["notice"])
+
+exports_files(["LICENSE"])
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "magic_enum",
+    hdrs = ["include/magic_enum.hpp"],
+    strip_include_prefix = "include",
+)
+
+cc_binary(
+    name = "example",
+    srcs = ["example/example.cpp"],
+    deps = [":magic_enum"],
+    copts = ["-std=c++17"],
+)
+
+cc_binary(
+    name = "enum_flag_example",
+    srcs = ["example/enum_flag_example.cpp"],
+    deps = [":magic_enum"],
+    copts = ["-std=c++17"],
+)
+
+cc_binary(
+    name = "example_custom_name",
+    srcs = ["example/example_custom_name.cpp"],
+    deps = [":magic_enum"],
+    copts = ["-std=c++17"],
+)
+
+cc_library(
+    name = "catch",
+    srcs = [],
+    hdrs = ["test/3rdparty/Catch2/catch.hpp"],
+    strip_include_prefix = "test/3rdparty/Catch2",
+)
+
+cc_test(
+    name = "test",
+    srcs = [
+        "test/test.cpp",
+    ],
+    deps = [":magic_enum", ":catch"],
+    copts = ["-std=c++17"],
+)
+cc_test(
+    name = "test_flags",
+    srcs = [
+        "test/test_flags.cpp",
+    ],
+    deps = [":magic_enum", ":catch"],
+    copts = ["-std=c++17"],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -13,22 +13,22 @@ cc_library(
 cc_binary(
     name = "example",
     srcs = ["example/example.cpp"],
-    deps = [":magic_enum"],
     copts = ["-std=c++17"],
+    deps = [":magic_enum"],
 )
 
 cc_binary(
     name = "enum_flag_example",
     srcs = ["example/enum_flag_example.cpp"],
-    deps = [":magic_enum"],
     copts = ["-std=c++17"],
+    deps = [":magic_enum"],
 )
 
 cc_binary(
     name = "example_custom_name",
     srcs = ["example/example_custom_name.cpp"],
-    deps = [":magic_enum"],
     copts = ["-std=c++17"],
+    deps = [":magic_enum"],
 )
 
 cc_library(
@@ -43,14 +43,21 @@ cc_test(
     srcs = [
         "test/test.cpp",
     ],
-    deps = [":magic_enum", ":catch"],
     copts = ["-std=c++17"],
+    deps = [
+        ":catch",
+        ":magic_enum",
+    ],
 )
+
 cc_test(
     name = "test_flags",
     srcs = [
         "test/test_flags.cpp",
     ],
-    deps = [":magic_enum", ":catch"],
     copts = ["-std=c++17"],
+    deps = [
+        ":catch",
+        ":magic_enum",
+    ],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,7 +7,7 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "magic_enum",
     hdrs = ["include/magic_enum.hpp"],
-    strip_include_prefix = "include",
+    includes = ["include"],
 )
 
 cc_binary(

--- a/README.md
+++ b/README.md
@@ -221,14 +221,20 @@ CPMAddPackage(
 
 Bazel is also supported, simply add to your WORKSPACE file:
 ```
-git_repository(
+http_archive(
     name = "magic_enum",
-    commit = <>,
-    remote = "https://github.com/Neargye/magic_enum",
+    strip_prefix = "magic_enum-<commit>",
+    urls = ["https://github.com/Neargye/magic_enum/archive/<commit>.zip"],
 )
 ```
+
 To use bazel inside the repository it's possible to do:
-`export CC=clang ; bazel build //... ; bazel test //... ; bazel run //:example`
+```
+bazel build //...
+bazel test //...
+bazel run //:example
+```
+(Note that you must use a supported compiler or specify it with `export CC= <compiler>`.)
 
 ## Compiler compatibility
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,17 @@ CPMAddPackage(
 )
 ```
 
+Bazel is also supported, simply add to your WORKSPACE file:
+```
+git_repository(
+    name = "magic_enum",
+    commit = <>,
+    remote = "https://github.com/Neargye/magic_enum",
+)
+```
+To use bazel inside the repository it's possible to do:
+`export CC=clang ; bazel build //... ; bazel test //... ; bazel run //:example`
+
 ## Compiler compatibility
 
 * Clang/LLVM >= 5


### PR DESCRIPTION
Bazel support for the magic_enum repository would help others using
bazel integrate this library into their projects.

This PR adds a BUILD file which enables magic_enum to be imported
seamlessly into other WORKSPACE files without having to write a custom
BUILD file.

It also adds bazel binaries & tests to enable running them via bazel
locally:

```
bazel build //... 
bazel test //... 
bazel run //:example
```

Finally, bazel compilation artifacts are added to the gitignore file.