### PR TITLE
Compile fix for gcc 7.5

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -402,19 +402,22 @@ constexpr E value(std::size_t i) noexcept {
   }
 }
 
+template <std::size_t N>
+constexpr std::size_t count_true(std::array<bool, N> valid_) noexcept {
+  auto count_ = std::size_t{0};
+  for (std::size_t i_ = 0; i_ < valid_.size(); ++i_) {
+    if (valid_[i_]) {
+      ++count_;
+    }
+  }
+  return count_;
+}
+
 template <typename E, bool IsFlags, int Min, std::size_t... I>
 constexpr auto values(std::index_sequence<I...>) noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::values requires enum type.");
   constexpr std::array<bool, sizeof...(I)> valid{{is_valid<E, value<E, Min, IsFlags>(I)>()...}};
-  constexpr std::size_t count = [](decltype((valid)) valid_) constexpr noexcept -> std::size_t {
-    auto count_ = std::size_t{0};
-    for (std::size_t i_ = 0; i_ < valid_.size(); ++i_) {
-      if (valid_[i_]) {
-        ++count_;
-      }
-    }
-    return count_;
-  }(valid);
+  constexpr std::size_t count = count_true(valid);
 
   std::array<E, count> values{};
   for (std::size_t i = 0, v = 0; v < count; ++i) {


### PR DESCRIPTION
I know that gcc 7.5 is not a compatible compiler, but I want to use this library (until we throw out gcc 7.5 support) as:

```
enum class SomeEnum : std::uint8_t {
    EnumVal1 = 0,
    EnumVal2 = 1
};

constexpr static auto someEnumNameArr = std::array{"EnumVal1", "EnumVal2"};

namespace magic_enum::customize {

    template <>
    constexpr std::string_view enum_name<SomeEnum>(SomeEnum val) noexcept {
        if (static_cast<std::underlying_type_t<SomeEnum>>(val) < someEnumNameArr.size())
            return someEnumNameArr.at(static_cast<std::underlying_type_t<SomeEnum>>(val));
        return "";
    }
}
```

Compile error on current code:

```
magic_enum.hpp: In function ‘constexpr auto magic_enum::detail::values(std::index_sequence<__indices ...>)’:
magic_enum.hpp:419:32: error: the value of ‘count’ is not usable in a constant expression
             std::array<E, count> values{};
                                ^
magic_enum.hpp:409:35: note: ‘count’ used in its own initializer
             constexpr std::size_t count = [](decltype((valid)) valid_) constexpr noexcept -> std::size_t {
                                   ^~~~~
magic_enum.hpp:419:32: note: in template argument for type ‘long unsigned int’ 
             std::array<E, count> values{};
                                ^
...
Internal compiler error: Error reporting routines re-entered.
Please submit a full bug report,
with preprocessed source if appropriate.
```

With this minimal change, the compiler error dissapears.