### PR TITLE
Detect values out of range and fail compilation

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -435,11 +435,30 @@ constexpr auto values(std::index_sequence<I...>) noexcept {
 }
 
 template <typename E, bool IsFlags, typename U = std::underlying_type_t<E>>
+inline static constexpr void detect_values_out_of_range()
+{
+  constexpr auto min = reflected_min_v<E, IsFlags>;
+  constexpr auto max = reflected_max_v<E, IsFlags>;
+  constexpr auto range_size = max - min + 1;
+
+  if constexpr (cmp_less((std::numeric_limits<U>::min)(), min) && !IsFlags)
+  {
+    static_assert(!is_valid<E, value<E, min - 1, IsFlags>(0)>(), "magic_enum detects enum value smaller than min range size");
+  }
+
+  if constexpr (cmp_less(range_size, (std::numeric_limits<U>::max)()) && !IsFlags)
+  {
+    static_assert(!is_valid<E, value<E, min, IsFlags>(range_size + 1)>(), "magic_enum detects enum value larger than max range size");
+  }
+}
+
+template <typename E, bool IsFlags, typename U = std::underlying_type_t<E>>
 constexpr auto values() noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::values requires enum type.");
   constexpr auto range_size = reflected_max_v<E, IsFlags> - reflected_min_v<E, IsFlags> + 1;
   static_assert(range_size > 0, "magic_enum::enum_range requires valid size.");
   static_assert(range_size < (std::numeric_limits<std::uint16_t>::max)(), "magic_enum::enum_range requires valid size.");
+  detect_values_out_of_range<E, IsFlags>();
 
   return values<E, IsFlags, reflected_min_v<E, IsFlags>>(std::make_index_sequence<range_size>{});
 }


### PR DESCRIPTION
This checks for a value at (range_min - 1) and (range_max + 1) and fails compilation with a static_assert if any value is found.

I put the check in `values()` -- is that the only location needed to enable it globally?

In my org it is preferable for this to be caught at build (compile) time rather than at runtime. Usually what happens is someone merges a PR that adds one more entry to an enum which exceeds the range_max, and it isn't detected until the software is behaving weirdly at runtime. We are using the range 0 - 64, and then we have to specialize for anything larger. `magic_enum` is unfortunately quite slow during compilation so narrowing the default range this much saved ~10% overall build time, but at the cost of needing to specialize (and running into this issue) more often.

Regarding implementation, technically this might break anyone who actually wants magic_enum to be missing some values, so maybe it should be behind some `#if` check that is enabled like `-DENABLE_MAGIC_ENUM_OFF_BY_ONE_RANGE_CHECK`. Also maybe this could be cleaner if refactored so that `min` and `max` were in `values()` and there was separate functions for checking min/max that could be each called by 2 `static_asserts` in `values()`.