### PR TITLE
Add build2 package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Github releases](https://img.shields.io/github/release/Neargye/magic_enum.svg)](https://github.com/Neargye/magic_enum/releases)
 [![Conan package](https://img.shields.io/badge/Conan-package-blueviolet)](https://conan.io/center/magic_enum)
 [![Vcpkg package](https://img.shields.io/badge/Vcpkg-package-blueviolet)](https://github.com/microsoft/vcpkg/tree/master/ports/magic-enum)
+[![Build2 package](https://img.shields.io/badge/Build2-package-blueviolet)](https://www.cppget.org/magic_enum?q=magic_enum)
 [![License](https://img.shields.io/github/license/Neargye/magic_enum.svg)](LICENSE)
 [![Build status](https://travis-ci.org/Neargye/magic_enum.svg?branch=master)](https://travis-ci.org/Neargye/magic_enum)
 [![Build status](https://ci.appveyor.com/api/projects/status/0rpr966p9ssrvwu3/branch/master?svg=true)](https://ci.appveyor.com/project/Neargye/magic-enum-hf8vk/branch/master)
@@ -208,6 +209,9 @@ enum class Color { RED = 2, BLUE = 4, GREEN = 8 };
 * If you are using [vcpkg](https://github.com/Microsoft/vcpkg/) on your project for external dependencies, then you can use the [magic-enum package](https://github.com/microsoft/vcpkg/tree/master/ports/magic-enum).
 
 * If you are using [Conan](https://www.conan.io/) to manage your dependencies, merely add `magic_enum/x.y.z` to your conan's requires, where `x.y.z` is the release version you want to use.
+
+* If you are using [Build2](https://build2.org/) to build and manage your dependencies, add `depends: magic_enum ^x.y.z`
+  to the manifest file where `x.y.z` is the release version you want to use (version 0.7.2+ is supported). You can then import the target using `magic_enum%lib{magic_enum}`.
 
 * Alternatively, you can use something like [CPM](https://github.com/TheLartians/CPM) which is based on CMake's `Fetch_Content` module.
 


### PR DESCRIPTION
We have packaged `magic_enum` for `Build2` (https://cppget.org/magic_enum?q=magic_enum) for version 0.7.2 and would propose adding information that links to the `Build2` package and basic information on how to import the library. The `Build2` port is located here https://github.com/build2-packaging/magic_enum.

I've added some links and quick explanation in the `README.md` on how to include `magic_enum` into a build2 project.