### PR TITLE
Add ARCH_INDEPENDENT so the generated cmake config files are really arch independent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required(VERSION 3.8)
+﻿cmake_minimum_required(VERSION 3.14)
 
 project(magic_enum VERSION "0.7.2" LANGUAGES CXX)
 
@@ -32,7 +32,8 @@ target_include_directories(${PROJECT_NAME}
 
 write_basic_package_version_file(${PROJECT_NAME}ConfigVersion.cmake
         VERSION ${PROJECT_VERSION}
-        COMPATIBILITY AnyNewerVersion)
+        COMPATIBILITY AnyNewerVersion
+        ARCH_INDEPENDENT)
 
 if(MAGIC_ENUM_OPT_INSTALL)
     install(TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
downside is that it at least requires cmake 3.14

closes #83