### PR TITLE
Add ability to include external configuration header

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -38,6 +38,22 @@
   #define MAGIC_ENUM_USING_ALIAS_OPTIONAL template <typename T> using optional = my_lib::Optional<T>;
   #include <magic_enum.hpp>
   ```
+  Optionally define `MAGIC_ENUM_CONFIG_FILE` i.e., in your build system, with path to header file with defined 
+  macros or constants, for example:
+  
+  ```cpp
+  #define MAGIC_ENUM_CONFIG_FILE "my_magic_enum_cfg.hpp"
+  ```
+  my_magic_enum_cfg.hpp:
+  ```cpp
+  #include <my_lib/string.hpp>
+  #include <my_lib/string_view.hpp>
+  #define MAGIC_ENUM_USING_ALIAS_STRING using string = my_lib::String;
+  #define MAGIC_ENUM_USING_ALIAS_STRING_VIEW using string_view = my_lib::StringView;
+  #define MAGIC_ENUM_USING_ALIAS_OPTIONAL template <typename T> using optional = my_lib::Optional<T>;
+  #define MAGIC_ENUM_RANGE_MIN 0
+  #define MAGIC_ENUM_RANGE_MAX 255
+  ```
 
 ## `enum_cast`
 

--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -45,6 +45,10 @@
 #include <type_traits>
 #include <utility>
 
+#if defined(MAGIC_ENUM_CONFIG_FILE)
+#include MAGIC_ENUM_CONFIG_FILE
+#endif
+
 #if !defined(MAGIC_ENUM_USING_ALIAS_OPTIONAL)
 #include <optional>
 #endif


### PR DESCRIPTION
Hello, 
I propose to add ability to include external user configuration file that will define all required constants, instead of using includes order (although this option stays available as well). 

MOTIVATION:
I'm working within tight embedded environment and I'm using ETL library instead of STL - it is more lightweight and avoids dynamic mem. alloc. 
While using documented method of setting for example MAGIC_ENUM_USING_ALIAS_STRING (by proper including order) is functional is also prone to errors and if other member of the team accidentally include magic_enum.hpp directly, std::string may be pulled. 
Approach with external cfg. file makes it far less likely.

