### PR TITLE
Remove optional<> with std::decay (Mac OS / Xcode)

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -738,7 +738,7 @@ template <typename E>
 // Obtains enum value from integer value.
 // Returns optional with enum value.
 template <typename E>
-[[nodiscard]] constexpr auto enum_cast(underlying_type_t<E> value) noexcept -> detail::enable_if_enum_t<E, optional<std::decay_t<E>>> {
+[[nodiscard]] constexpr auto enum_cast(underlying_type_t<E> value) noexcept -> detail::enable_if_enum_t<E, std::decay_t<E>> {
   using D = std::decay_t<E>;
 
   if (detail::undex<D>(value) != detail::invalid_index_v<D>) {
@@ -751,7 +751,7 @@ template <typename E>
 // Obtains enum value from name.
 // Returns optional with enum value.
 template <typename E, typename BinaryPredicate>
-[[nodiscard]] constexpr auto enum_cast(string_view value, BinaryPredicate p) noexcept(std::is_nothrow_invocable_r_v<bool, BinaryPredicate, char, char>) -> detail::enable_if_enum_t<E, optional<std::decay_t<E>>> {
+[[nodiscard]] constexpr auto enum_cast(string_view value, BinaryPredicate p) noexcept(std::is_nothrow_invocable_r_v<bool, BinaryPredicate, char, char>) -> detail::enable_if_enum_t<E, std::decay_t<E>> {
   static_assert(std::is_invocable_r_v<bool, BinaryPredicate, char, char>, "magic_enum::enum_cast requires bool(char, char) invocable predicate.");
   using D = std::decay_t<E>;
 
@@ -767,7 +767,7 @@ template <typename E, typename BinaryPredicate>
 // Obtains enum value from name.
 // Returns optional with enum value.
 template <typename E>
-[[nodiscard]] constexpr auto enum_cast(string_view value) noexcept -> detail::enable_if_enum_t<E, optional<std::decay_t<E>>> {
+[[nodiscard]] constexpr auto enum_cast(string_view value) noexcept -> detail::enable_if_enum_t<E, std::decay_t<E>> {
   using D = std::decay_t<E>;
 
   return enum_cast<D>(value, detail::char_equal_to{});
@@ -782,7 +782,7 @@ template <typename E>
 // Obtains index in enum values from enum value.
 // Returns optional with index.
 template <typename E>
-[[nodiscard]] constexpr auto enum_index(E value) noexcept -> detail::enable_if_enum_t<E, optional<std::size_t>> {
+[[nodiscard]] constexpr auto enum_index(E value) noexcept -> detail::enable_if_enum_t<E, std::size_t> {
   using D = std::decay_t<E>;
 
   if (const auto i = detail::endex<D>(value); i != detail::invalid_index_v<D>) {
@@ -974,7 +974,7 @@ template <typename E>
 // Obtains enum-flags value from integer value.
 // Returns optional with enum-flags value.
 template <typename E>
-[[nodiscard]] constexpr auto enum_cast(underlying_type_t<E> value) noexcept -> detail::enable_if_enum_t<E, optional<std::decay_t<E>>> {
+[[nodiscard]] constexpr auto enum_cast(underlying_type_t<E> value) noexcept -> detail::enable_if_enum_t<E, std::decay_t<E>> {
   using D = std::decay_t<E>;
   using U = underlying_type_t<D>;
 
@@ -1004,7 +1004,7 @@ template <typename E>
 // Obtains enum-flags value from name.
 // Returns optional with enum-flags value.
 template <typename E, typename BinaryPredicate>
-[[nodiscard]] constexpr auto enum_cast(string_view value, BinaryPredicate p) noexcept(std::is_nothrow_invocable_r_v<bool, BinaryPredicate, char, char>) -> detail::enable_if_enum_t<E, optional<std::decay_t<E>>> {
+[[nodiscard]] constexpr auto enum_cast(string_view value, BinaryPredicate p) noexcept(std::is_nothrow_invocable_r_v<bool, BinaryPredicate, char, char>) -> detail::enable_if_enum_t<E, std::decay_t<E>> {
   static_assert(std::is_invocable_r_v<bool, BinaryPredicate, char, char>, "magic_enum::flags::enum_cast requires bool(char, char) invocable predicate.");
   using D = std::decay_t<E>;
   using U = underlying_type_t<D>;
@@ -1037,7 +1037,7 @@ template <typename E, typename BinaryPredicate>
 // Obtains enum-flags value from name.
 // Returns optional with enum-flags value.
 template <typename E>
-[[nodiscard]] constexpr auto enum_cast(string_view value) noexcept -> detail::enable_if_enum_t<E, optional<std::decay_t<E>>> {
+[[nodiscard]] constexpr auto enum_cast(string_view value) noexcept -> detail::enable_if_enum_t<E, std::decay_t<E>> {
   using D = std::decay_t<E>;
 
   return enum_cast<D>(value, detail::char_equal_to{});


### PR DESCRIPTION
I don't have a good explanation for why, but an optional<> type is considered by Clang on Mac OS (using Xcode) to be different from, and not convertible into, the same type without optional<> therefore magic_enum builds produced SFINAE errors, as the optional<> type does not appear to be an enum accordig to enable_if_enum_t<>. Solved by removing optional<> template instantiation around each std::decay<>