### PR TITLE
Add simple meson.build to make this repository as a subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,11 @@
+project(
+    'magic_enum', ['cpp'],
+    default_options: ['cpp_std=c++17'],
+    version: '0.7.3',
+)
+
+magic_enum_include = include_directories('include')
+
+magic_enum_dep = declare_dependency(
+    include_directories: magic_enum_include,
+)


### PR DESCRIPTION
In Meson, you can use [wraps](https://mesonbuild.com/Wrap-dependency-system-manual.html) to define subprojects, or external dependencies. The subproject directory must contain a `meson.build`. This repository does not contain one. A solution is to add an overlay into the wrap file or to simply add a `meson.build` here. In our projects, we need to support 2 build systems, hence we don't use wrap file and directly use this repository as a git submodule. We need to manually add the `meson.build` file.

There is a [CMake module](https://mesonbuild.com/CMake-module.html) for Meson and it work fine for normal builds. We weren't able to use this module when we were cross-compiling. Hence, it is another reason why we think it should be here.

Finally, the `meson.build` file is small and won't require significant maintenance (only the version number could be updated). The main build system should still be CMake. The Meson one don't need to run tests or do anything else.