### PR TITLE
remove static assert for static string because it does not solve issue

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -180,7 +180,6 @@ struct char_equal_to {
 
 template <std::size_t N>
 class static_string {
-static_assert(N < UINT16_MAX, "Length of static_string must be less than UINT16_MAX.");
  public:
   constexpr explicit static_string(string_view str) noexcept : static_string{str, std::make_index_sequence<N>{}} {
     assert(str.size() == N);


### PR DESCRIPTION
This PR reverses #123 because the `static_assert` that I added did not solve the issue. In fact, it just adds a second IntelliSense error on top of the first. I am starting to think this is a bug in VS 2022 IntelliSense and it is probably better just to ignore it.