### PR TITLE
support gcc8 with defined MAGIC_ENUM_NO_CHECK_SUPPORT and with specialized magic_enum::customize::enum_name

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -336,11 +336,11 @@ constexpr auto n() noexcept {
 #  elif defined(_MSC_VER)
       constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 17});
 #  else
-      constexpr std::string_view name = "";
+      constexpr string_view name = "";
 #  endif
       return static_string<name.size()>{name};
   } else {
-      return std::string_view{}; // Unsupported compiler.
+      return string_view{}; // Unsupported compiler.
   }
 }
 

--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -534,7 +534,7 @@ constexpr auto names(std::index_sequence<I...>) noexcept {
 }
 
 template <typename E>
-inline constexpr auto names_v = names<E>(std::make_index_sequence<count_v<E>>{});
+inline constexpr std::array names_v = names<E>(std::make_index_sequence<count_v<E>>{});
 
 template <typename E, typename D = std::decay_t<E>>
 using names_t = decltype((names_v<D>));

--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -330,17 +330,18 @@ inline constexpr bool is_enum_v = std::is_enum_v<T> && std::is_same_v<T, std::de
 template <typename E>
 constexpr auto n() noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::n requires enum type.");
+
   if constexpr (supported<E>::value) {
-#  if defined(__clang__) || defined(__GNUC__)
-      constexpr auto name = pretty_name({__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 2});
-#  elif defined(_MSC_VER)
-      constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 17});
-#  else
-      constexpr string_view name = "";
-#  endif
-      return static_string<name.size()>{name};
+#if defined(__clang__) || defined(__GNUC__)
+    constexpr auto name = pretty_name({__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 2});
+#elif defined(_MSC_VER)
+    constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 17});
+#else
+    constexpr auto name = string_view{};
+#endif
+    return static_string<name.size()>{name};
   } else {
-      return string_view{}; // Unsupported compiler.
+    return string_view{}; // Unsupported compiler.
   }
 }
 
@@ -949,13 +950,14 @@ template <typename Char, typename Traits, typename E, detail::enable_if_enum_t<E
 std::basic_ostream<Char, Traits>& operator<<(std::basic_ostream<Char, Traits>& os, E value) {
   using D = std::decay_t<E>;
   using U = underlying_type_t<D>;
+
   if constexpr (detail::supported<D>::value) {
-      if (const auto name = magic_enum::enum_flags_name<D>(value); !name.empty()) {
-          for (const auto c : name) {
-              os.put(c);
-          }
-          return os;
+    if (const auto name = magic_enum::enum_flags_name<D>(value); !name.empty()) {
+      for (const auto c : name) {
+        os.put(c);
       }
+      return os;
+    }
   }
   return (os << static_cast<U>(value));
 }

--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -330,16 +330,18 @@ inline constexpr bool is_enum_v = std::is_enum_v<T> && std::is_same_v<T, std::de
 template <typename E>
 constexpr auto n() noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::n requires enum type.");
-#if defined(MAGIC_ENUM_SUPPORTED) && MAGIC_ENUM_SUPPORTED
+  if constexpr (supported<E>::value) {
 #  if defined(__clang__) || defined(__GNUC__)
-  constexpr auto name = pretty_name({__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 2});
+      constexpr auto name = pretty_name({__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 2});
 #  elif defined(_MSC_VER)
-  constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 17});
+      constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 17});
+#  else
+      constexpr std::string_view name = "";
 #  endif
-  return static_string<name.size()>{name};
-#else
-  return string_view{}; // Unsupported compiler.
-#endif
+      return static_string<name.size()>{name};
+  } else {
+      return std::string_view{}; // Unsupported compiler.
+  }
 }
 
 template <typename E>
@@ -510,7 +512,7 @@ template <typename E>
 inline constexpr bool is_flags_v = is_flags_enum<E>();
 
 template <typename E>
-inline constexpr auto values_v = values<E, is_flags_v<E>>();
+inline constexpr std::array values_v = values<E, is_flags_v<E>>();
 
 template <typename E, typename D = std::decay_t<E>>
 using values_t = decltype((values_v<D>));
@@ -545,7 +547,7 @@ constexpr auto entries(std::index_sequence<I...>) noexcept {
 }
 
 template <typename E>
-inline constexpr auto entries_v = entries<E>(std::make_index_sequence<count_v<E>>{});
+inline constexpr std::array entries_v = entries<E>(std::make_index_sequence<count_v<E>>{});
 
 template <typename E, typename D = std::decay_t<E>>
 using entries_t = decltype((entries_v<D>));
@@ -871,7 +873,7 @@ template <typename E>
   } else {
     const auto v = static_cast<U>(value);
     if (v >= detail::min_v<D> && v <= detail::max_v<D>) {
-      return static_cast<std::size_t>(v - detail::min_v<E>);
+      return static_cast<std::size_t>(v - detail::min_v<D>);
     }
   }
 
@@ -947,14 +949,14 @@ template <typename Char, typename Traits, typename E, detail::enable_if_enum_t<E
 std::basic_ostream<Char, Traits>& operator<<(std::basic_ostream<Char, Traits>& os, E value) {
   using D = std::decay_t<E>;
   using U = underlying_type_t<D>;
-#if defined(MAGIC_ENUM_SUPPORTED) && MAGIC_ENUM_SUPPORTED
-  if (const auto name = magic_enum::enum_flags_name<D>(value); !name.empty()) {
-    for (const auto c : name) {
-      os.put(c);
-    }
-    return os;
+  if constexpr (detail::supported<D>::value) {
+      if (const auto name = magic_enum::enum_flags_name<D>(value); !name.empty()) {
+          for (const auto c : name) {
+              os.put(c);
+          }
+          return os;
+      }
   }
-#endif
   return (os << static_cast<U>(value));
 }
 


### PR DESCRIPTION
I tried to run examples and tests with gcc8, with manually specialized `magic_enum::customize::enum_name`.
I know that GCC8 is not supported, but these changes help us to make compatible our code with older GCC too only with the custom template function.

---

I replaced 
`#if defined(MAGIC_ENUM_SUPPORTED) && MAGIC_ENUM_SUPPORTED`
macros to 
`if constexpr (supported<E>::value) {`

at class name getter `n()`, and  `operator<<`
These functions work with custom `magic_enum::customize::enum_name`, so it is enough to check `supported` flag.

---

I replaced  `detail::min_v<E>` template parameter `E`, because `E` can be a reference, and `std::underlying_type` is undefined in some compilers when the template parameter is a reference.

---

I switched `values_v` and `entries_v` from `auto` to `std::array`, because GCC8 is not able to deduct the whole type, but `std::array` template parameters. This change should not change the newer compilers (and it is not a big change)
