### PR TITLE
Simplier change only one enum instance name

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -148,7 +148,7 @@ constexpr string_view enum_name(E) noexcept {
 }
 
 // If need custom name only for one enum, add specialization enum_name_v for that instance.
-template <typename E, E V>
+template <auto V, typename E = decltype(V)>
 inline constexpr auto enum_name_v = detail::n<E, V>();
 
 } // namespace magic_enum::customize
@@ -380,7 +380,7 @@ template <typename E, auto V>
 constexpr bool is_valid() noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::is_valid requires enum type.");
 
-  return customize::enum_name_v<E, static_cast<E>(V)>.size() != 0;
+  return customize::enum_name_v<static_cast<E>(V)>.size() != 0;
 }
 
 template <typename E, int O, bool IsFlags, typename U = std::underlying_type_t<E>>
@@ -534,7 +534,7 @@ template <typename E, std::size_t... I>
 constexpr auto names(std::index_sequence<I...>) noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::names requires enum type.");
 
-  return std::array<string_view, sizeof...(I)>{{customize::enum_name_v<E, values_v<E>[I]>...}};
+  return std::array<string_view, sizeof...(I)>{{customize::enum_name_v<values_v<E>[I]>...}};
 }
 
 template <typename E>
@@ -547,7 +547,7 @@ template <typename E, std::size_t... I>
 constexpr auto entries(std::index_sequence<I...>) noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::entries requires enum type.");
 
-  return std::array<std::pair<E, string_view>, sizeof...(I)>{{{values_v<E>[I], customize::enum_name_v<E, values_v<E>[I]>}...}};
+  return std::array<std::pair<E, string_view>, sizeof...(I)>{{{values_v<E>[I], customize::enum_name_v<values_v<E>[I]>}...}};
 }
 
 template <typename E>
@@ -694,7 +694,7 @@ template <typename E>
 // This version is much lighter on the compile times and is not restricted to the enum_range limitation.
 template <auto V, typename E = decltype(V)>
 [[nodiscard]] constexpr auto enum_name() noexcept -> detail::enable_if_enum_t<E, string_view> {
-  constexpr string_view name = customize::enum_name_v<E, V>;
+  constexpr string_view name = customize::enum_name_v<V>;
   static_assert(name.size() > 0, "Enum value does not have a name.");
 
   return name;

--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -148,8 +148,8 @@ constexpr string_view enum_name(E) noexcept {
 }
 
 // If need custom name only for one enum, add specialization enum_name_v for that instance.
-template <typename E, E V>
-inline constexpr auto enum_name_v = detail::n<E, V>();
+template <auto V>
+inline constexpr auto enum_name_v = detail::n<decltype(V), V>();
 
 } // namespace magic_enum::customize
 
@@ -380,7 +380,7 @@ template <typename E, auto V>
 constexpr bool is_valid() noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::is_valid requires enum type.");
 
-  return n<E, static_cast<E>(V)>().size() != 0;
+  return customize::enum_name_v<static_cast<E>(V)>.size() != 0;
 }
 
 template <typename E, int O, bool IsFlags, typename U = std::underlying_type_t<E>>
@@ -534,7 +534,7 @@ template <typename E, std::size_t... I>
 constexpr auto names(std::index_sequence<I...>) noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::names requires enum type.");
 
-  return std::array<string_view, sizeof...(I)>{{customize::enum_name_v<E, values_v<E>[I]>...}};
+  return std::array<string_view, sizeof...(I)>{{customize::enum_name_v<values_v<E>[I]>...}};
 }
 
 template <typename E>
@@ -547,7 +547,7 @@ template <typename E, std::size_t... I>
 constexpr auto entries(std::index_sequence<I...>) noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::entries requires enum type.");
 
-  return std::array<std::pair<E, string_view>, sizeof...(I)>{{{values_v<E>[I], customize::enum_name_v<E, values_v<E>[I]>}...}};
+  return std::array<std::pair<E, string_view>, sizeof...(I)>{{{values_v<E>[I], customize::enum_name_v<values_v<E>[I]>}...}};
 }
 
 template <typename E>
@@ -694,7 +694,7 @@ template <typename E>
 // This version is much lighter on the compile times and is not restricted to the enum_range limitation.
 template <auto V>
 [[nodiscard]] constexpr auto enum_name() noexcept -> detail::enable_if_enum_t<decltype(V), string_view> {
-  constexpr string_view name = customize::enum_name_v<std::decay_t<decltype(V)>, V>;
+  constexpr string_view name = customize::enum_name_v<V>;
   static_assert(name.size() > 0, "Enum value does not have a name.");
 
   return name;

--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -148,8 +148,8 @@ constexpr string_view enum_name(E) noexcept {
 }
 
 // If need custom name only for one enum, add specialization enum_name_v for that instance.
-template <auto V>
-inline constexpr auto enum_name_v = detail::n<decltype(V), V>();
+template <typename E, E V>
+inline constexpr auto enum_name_v = detail::n<E, V>();
 
 } // namespace magic_enum::customize
 
@@ -380,7 +380,7 @@ template <typename E, auto V>
 constexpr bool is_valid() noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::is_valid requires enum type.");
 
-  return customize::enum_name_v<static_cast<E>(V)>.size() != 0;
+  return customize::enum_name_v<E, static_cast<E>(V)>.size() != 0;
 }
 
 template <typename E, int O, bool IsFlags, typename U = std::underlying_type_t<E>>
@@ -534,7 +534,7 @@ template <typename E, std::size_t... I>
 constexpr auto names(std::index_sequence<I...>) noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::names requires enum type.");
 
-  return std::array<string_view, sizeof...(I)>{{customize::enum_name_v<values_v<E>[I]>...}};
+  return std::array<string_view, sizeof...(I)>{{customize::enum_name_v<E, values_v<E>[I]>...}};
 }
 
 template <typename E>
@@ -547,7 +547,7 @@ template <typename E, std::size_t... I>
 constexpr auto entries(std::index_sequence<I...>) noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::entries requires enum type.");
 
-  return std::array<std::pair<E, string_view>, sizeof...(I)>{{{values_v<E>[I], customize::enum_name_v<values_v<E>[I]>}...}};
+  return std::array<std::pair<E, string_view>, sizeof...(I)>{{{values_v<E>[I], customize::enum_name_v<E, values_v<E>[I]>}...}};
 }
 
 template <typename E>
@@ -694,7 +694,7 @@ template <typename E>
 // This version is much lighter on the compile times and is not restricted to the enum_range limitation.
 template <auto V>
 [[nodiscard]] constexpr auto enum_name() noexcept -> detail::enable_if_enum_t<decltype(V), string_view> {
-  constexpr string_view name = customize::enum_name_v<V>;
+  constexpr string_view name = customize::enum_name_v<decltype(V), V>;
   static_assert(name.size() > 0, "Enum value does not have a name.");
 
   return name;

--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -692,9 +692,9 @@ template <typename E>
 
 // Returns name from static storage enum variable.
 // This version is much lighter on the compile times and is not restricted to the enum_range limitation.
-template <auto V>
-[[nodiscard]] constexpr auto enum_name() noexcept -> detail::enable_if_enum_t<decltype(V), string_view> {
-  constexpr string_view name = customize::enum_name_v<decltype(V), V>;
+template <auto V, typename E = decltype(V)>
+[[nodiscard]] constexpr auto enum_name() noexcept -> detail::enable_if_enum_t<E, string_view> {
+  constexpr string_view name = customize::enum_name_v<E, V>;
   static_assert(name.size() > 0, "Enum value does not have a name.");
 
   return name;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -38,6 +38,8 @@ enum class Color { RED = -12, GREEN = 7, BLUE = 15 };
 
 enum class Numbers : int { one = 1, two, three, many = 127 };
 
+constexpr auto NumberFour = static_cast<Numbers>(4);
+
 enum Directions { Up = 85, Down = -42, Right = 120, Left = -120 };
 
 #if defined(MAGIC_ENUM_ENABLE_NONASCII)
@@ -100,6 +102,10 @@ constexpr std::string_view enum_name_v<Binary::ONE> = "1";
 
 template<>
 constexpr std::string_view enum_name_v<Numbers::two>{};
+
+template<>
+constexpr std::string_view enum_name_v<NumberFour> = "four";
+
 }
 
 using namespace magic_enum;
@@ -117,6 +123,7 @@ TEST_CASE("enum_cast") {
     constexpr auto no = enum_cast<Numbers>("one");
     REQUIRE(no.value() == Numbers::one);
     REQUIRE(enum_cast<Numbers>("three").value() == Numbers::three);
+    REQUIRE(enum_cast<Numbers>("four").value() == NumberFour);
     REQUIRE_FALSE(enum_cast<Numbers>("two").has_value());
     REQUIRE_FALSE(enum_cast<Numbers>("many").has_value());
     REQUIRE_FALSE(enum_cast<Numbers>("None").has_value());
@@ -156,6 +163,7 @@ TEST_CASE("enum_cast") {
     constexpr auto no = enum_cast<Numbers>(1);
     REQUIRE(no.value() == Numbers::one);
     REQUIRE(enum_cast<Numbers>(3).value() == Numbers::three);
+    REQUIRE(enum_cast<Numbers>(4).value() == NumberFour);
     REQUIRE_FALSE(enum_cast<Numbers>(2).has_value());
     REQUIRE_FALSE(enum_cast<Numbers>(127).has_value());
     REQUIRE_FALSE(enum_cast<Numbers>(0).has_value());
@@ -198,6 +206,7 @@ TEST_CASE("enum_integer") {
   REQUIRE(no == 1);
   REQUIRE(enum_integer(Numbers::two) == 2);
   REQUIRE(enum_integer(Numbers::three) == 3);
+  REQUIRE(enum_integer(NumberFour) == 4);
   REQUIRE(enum_integer(Numbers::many) == 127);
   REQUIRE(enum_integer(static_cast<Numbers>(0)) == 0);
 
@@ -239,6 +248,7 @@ TEST_CASE("enum_index") {
   constexpr auto no = enum_index(Numbers::one);
   REQUIRE(no.value() == 0);
   REQUIRE(enum_index(Numbers::three).value() == 1);
+  REQUIRE(enum_index(NumberFour).value() == 2);
   REQUIRE_FALSE(enum_index(Numbers::two).has_value());
   REQUIRE_FALSE(enum_index(Numbers::many).has_value());
   REQUIRE_FALSE(enum_index(static_cast<Numbers>(0)).has_value());
@@ -282,6 +292,7 @@ TEST_CASE("enum_contains") {
     constexpr auto no = enum_contains(Numbers::one);
     REQUIRE(no);
     REQUIRE(enum_contains(Numbers::three));
+    REQUIRE(enum_contains(NumberFour));
     REQUIRE_FALSE(enum_contains(Numbers::two));
     REQUIRE_FALSE(enum_contains(Numbers::many));
     REQUIRE_FALSE(enum_contains(static_cast<Numbers>(0)));
@@ -323,6 +334,7 @@ TEST_CASE("enum_contains") {
     constexpr auto no = enum_integer(Numbers::one);
     REQUIRE(enum_contains<Numbers>(no));
     REQUIRE(enum_contains<Numbers>(enum_integer(Numbers::three)));
+    REQUIRE(enum_contains<Numbers>(enum_integer(NumberFour)));
     REQUIRE_FALSE(enum_contains<Numbers>(enum_integer(Numbers::two)));
     REQUIRE_FALSE(enum_contains<Numbers>(enum_integer(Numbers::many)));
 
@@ -362,6 +374,7 @@ TEST_CASE("enum_contains") {
     constexpr auto no = std::string_view{"one"};
     REQUIRE(enum_contains<Numbers>(no));
     REQUIRE(enum_contains<Numbers>("three"));
+    REQUIRE(enum_contains<Numbers>("four"));
     REQUIRE_FALSE(enum_contains<Numbers>("two"));
     REQUIRE_FALSE(enum_contains<Numbers>("many"));
     REQUIRE_FALSE(enum_contains<Numbers>("None"));
@@ -407,6 +420,7 @@ TEST_CASE("enum_value") {
 
   REQUIRE(enum_value<Numbers, 0>() == Numbers::one);
   REQUIRE(enum_value<Numbers, 1>() == Numbers::three);
+  REQUIRE(enum_value<Numbers, 2>() == NumberFour);
 
   constexpr auto dr = enum_value<Directions>(3);
   REQUIRE(enum_value<Directions&>(0) == Directions::Left);
@@ -444,7 +458,7 @@ TEST_CASE("enum_values") {
   REQUIRE(s1 == std::array<Color, 3>{{Color::RED, Color::GREEN, Color::BLUE}});
 
   constexpr auto& s2 = enum_values<Numbers>();
-  REQUIRE(s2 == std::array<Numbers, 2>{{Numbers::one, Numbers::three}});
+  REQUIRE(s2 == std::array<Numbers, 3>{{Numbers::one, Numbers::three, NumberFour}});
 
   constexpr auto& s3 = enum_values<const Directions>();
   REQUIRE(s3 == std::array<Directions, 4>{{Directions::Left, Directions::Down, Directions::Up, Directions::Right}});
@@ -469,7 +483,7 @@ TEST_CASE("enum_count") {
   REQUIRE(s1 == 3);
 
   constexpr auto s2 = enum_count<Numbers>();
-  REQUIRE(s2 == 2);
+  REQUIRE(s2 == 3);
 
   constexpr auto s3 = enum_count<const Directions>();
   REQUIRE(s3 == 4);
@@ -504,6 +518,7 @@ TEST_CASE("enum_name") {
     constexpr auto no_name = enum_name(no);
     REQUIRE(no_name == "one");
     REQUIRE(enum_name(Numbers::three) == "three");
+    REQUIRE(enum_name(NumberFour) == "four");
     REQUIRE(enum_name(Numbers::two).empty());
     REQUIRE(enum_name(Numbers::many).empty());
     REQUIRE(enum_name(static_cast<Numbers>(0)).empty());
@@ -549,6 +564,7 @@ TEST_CASE("enum_name") {
     constexpr auto no_name = enum_name<no>();
     REQUIRE(no_name == "one");
     REQUIRE(enum_name<Numbers::three>() == "three");
+    REQUIRE(enum_name<NumberFour>() == "four");
     REQUIRE(enum_name<Numbers::many>() == "many");
 
     constexpr Directions dr = Directions::Right;
@@ -586,7 +602,7 @@ TEST_CASE("enum_names") {
   REQUIRE(s1 == std::array<std::string_view, 3>{{"red", "GREEN", "BLUE"}});
 
   constexpr auto& s2 = enum_names<Numbers>();
-  REQUIRE(s2 == std::array<std::string_view, 2>{{"one", "three"}});
+  REQUIRE(s2 == std::array<std::string_view, 3>{{"one", "three", "four"}});
 
   constexpr auto& s3 = enum_names<const Directions>();
   REQUIRE(s3 == std::array<std::string_view, 4>{{"Left", "Down", "Up", "Right"}});
@@ -607,7 +623,7 @@ TEST_CASE("enum_entries") {
   REQUIRE(s1 == std::array<std::pair<Color, std::string_view>, 3>{{{Color::RED, "red"}, {Color::GREEN, "GREEN"}, {Color::BLUE, "BLUE"}}});
 
   constexpr auto& s2 = enum_entries<Numbers>();
-  REQUIRE(s2 == std::array<std::pair<Numbers, std::string_view>, 2>{{{Numbers::one, "one"}, {Numbers::three, "three"}}});
+  REQUIRE(s2 == std::array<std::pair<Numbers, std::string_view>, 3>{{{Numbers::one, "one"}, {Numbers::three, "three"}, {NumberFour, "four"}}});
 
   constexpr auto& s3 = enum_entries<Directions&>();
   REQUIRE(s3 == std::array<std::pair<Directions, std::string_view>, 4>{{{Directions::Left, "Left"}, {Directions::Down, "Down"}, {Directions::Up, "Up"}, {Directions::Right, "Right"}}});
@@ -638,6 +654,7 @@ TEST_CASE("ostream_operators") {
   test_ostream(std::make_optional(Numbers::one), "one");
   test_ostream(Numbers::two, "2");
   test_ostream(Numbers::three, "three");
+  test_ostream(NumberFour, "four");
   test_ostream(Numbers::many, "127");
   test_ostream(static_cast<Numbers>(0), "0");
   test_ostream(std::make_optional(static_cast<Numbers>(0)), "0");
@@ -691,7 +708,7 @@ TEST_CASE("bitwise_operators") {
 
   SECTION("operator&") {
     REQUIRE(enum_integer(Color::RED & Color::BLUE) == (enum_integer(Color::RED) & enum_integer(Color::BLUE)));
-    REQUIRE(enum_integer(Numbers::one & Numbers::two) == (enum_integer(Numbers::one) & enum_integer(Numbers::two)));
+    REQUIRE(enum_integer(Numbers::one & NumberFour) == (enum_integer(Numbers::one) & enum_integer(NumberFour)));
     REQUIRE(enum_integer(Directions::Up & Directions::Down) == (enum_integer(Directions::Up) & enum_integer(Directions::Down)));
 #if defined(MAGIC_ENUM_ENABLE_NONASCII)
     REQUIRE(enum_integer(Language::日本語 & Language::한국어) == (enum_integer(Language::日本語) & enum_integer(Language::한국어)));
@@ -890,7 +907,7 @@ TEST_CASE("extrema") {
 
     REQUIRE(magic_enum::customize::enum_range<Numbers>::max == MAGIC_ENUM_RANGE_MAX);
     REQUIRE(magic_enum::detail::reflected_max_v<Numbers, false> == MAGIC_ENUM_RANGE_MAX);
-    REQUIRE(magic_enum::detail::max_v<Numbers> == 3);
+    REQUIRE(magic_enum::detail::max_v<Numbers> == 4);
 
     REQUIRE(magic_enum::customize::enum_range<Directions>::max == MAGIC_ENUM_RANGE_MAX);
     REQUIRE(magic_enum::detail::reflected_max_v<Directions, false> == MAGIC_ENUM_RANGE_MAX);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -96,10 +96,10 @@ constexpr std::string_view magic_enum::customize::enum_name<Color>(Color value) 
 
 namespace magic_enum::customize {
 template<>
-constexpr std::string_view enum_name_v<Binary::ONE> = "1";
+constexpr std::string_view enum_name_v<Binary, Binary::ONE> = "1";
 
 template<>
-constexpr std::string_view enum_name_v<Numbers::two>{};
+constexpr std::string_view enum_name_v<Numbers, Numbers::two>{};
 }
 
 using namespace magic_enum;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -99,6 +99,9 @@ template<>
 constexpr std::string_view enum_name_v<Binary, Binary::ONE> = "1";
 
 template<>
+constexpr std::string_view enum_name_v<MaxUsedAsInvalid, MaxUsedAsInvalid::ONE> = "ONE";
+
+template<>
 constexpr std::string_view enum_name_v<Numbers, Numbers::two>{};
 }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -94,6 +94,9 @@ constexpr std::string_view magic_enum::customize::enum_name<Color>(Color value) 
   }
 }
 
+template<>
+constexpr std::string_view magic_enum::customize::enum_name_v<Binary, Binary::ONE> = "1";
+
 using namespace magic_enum;
 
 static_assert(is_magic_enum_supported, "magic_enum: Unsupported compiler (https://github.com/Neargye/magic_enum#compiler-compatibility).");
@@ -569,7 +572,7 @@ TEST_CASE("enum_name") {
     REQUIRE(nt_name == "three");
     REQUIRE(enum_name<number::four>() == "four");
 
-    REQUIRE(enum_name<Binary::ONE>() == "ONE");
+    REQUIRE(enum_name<Binary::ONE>() == "1");
     REQUIRE(enum_name<MaxUsedAsInvalid::ONE>() == "ONE");
   }
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -94,12 +94,13 @@ constexpr std::string_view magic_enum::customize::enum_name<Color>(Color value) 
   }
 }
 
+namespace magic_enum::customize {
 template<>
-constexpr std::string_view magic_enum::customize::enum_name_v<Binary::ONE> = "1";
+constexpr std::string_view enum_name_v<Binary::ONE> = "1";
 
 template<>
-constexpr std::string_view magic_enum::customize::enum_name_v<Numbers::two>{};
-
+constexpr std::string_view enum_name_v<Numbers::two>{};
+}
 
 using namespace magic_enum;
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -95,7 +95,11 @@ constexpr std::string_view magic_enum::customize::enum_name<Color>(Color value) 
 }
 
 template<>
-constexpr std::string_view magic_enum::customize::enum_name_v<Binary, Binary::ONE> = "1";
+constexpr std::string_view magic_enum::customize::enum_name_v<Binary::ONE> = "1";
+
+template<>
+constexpr std::string_view magic_enum::customize::enum_name_v<Numbers::two>{};
+
 
 using namespace magic_enum;
 
@@ -111,8 +115,8 @@ TEST_CASE("enum_cast") {
 
     constexpr auto no = enum_cast<Numbers>("one");
     REQUIRE(no.value() == Numbers::one);
-    REQUIRE(enum_cast<Numbers>("two").value() == Numbers::two);
     REQUIRE(enum_cast<Numbers>("three").value() == Numbers::three);
+    REQUIRE_FALSE(enum_cast<Numbers>("two").has_value());
     REQUIRE_FALSE(enum_cast<Numbers>("many").has_value());
     REQUIRE_FALSE(enum_cast<Numbers>("None").has_value());
 
@@ -150,8 +154,8 @@ TEST_CASE("enum_cast") {
 
     constexpr auto no = enum_cast<Numbers>(1);
     REQUIRE(no.value() == Numbers::one);
-    REQUIRE(enum_cast<Numbers>(2).value() == Numbers::two);
     REQUIRE(enum_cast<Numbers>(3).value() == Numbers::three);
+    REQUIRE_FALSE(enum_cast<Numbers>(2).has_value());
     REQUIRE_FALSE(enum_cast<Numbers>(127).has_value());
     REQUIRE_FALSE(enum_cast<Numbers>(0).has_value());
 
@@ -233,8 +237,8 @@ TEST_CASE("enum_index") {
 
   constexpr auto no = enum_index(Numbers::one);
   REQUIRE(no.value() == 0);
-  REQUIRE(enum_index(Numbers::two).value() == 1);
-  REQUIRE(enum_index(Numbers::three).value() == 2);
+  REQUIRE(enum_index(Numbers::three).value() == 1);
+  REQUIRE_FALSE(enum_index(Numbers::two).has_value());
   REQUIRE_FALSE(enum_index(Numbers::many).has_value());
   REQUIRE_FALSE(enum_index(static_cast<Numbers>(0)).has_value());
 
@@ -276,8 +280,8 @@ TEST_CASE("enum_contains") {
 
     constexpr auto no = enum_contains(Numbers::one);
     REQUIRE(no);
-    REQUIRE(enum_contains(Numbers::two));
     REQUIRE(enum_contains(Numbers::three));
+    REQUIRE_FALSE(enum_contains(Numbers::two));
     REQUIRE_FALSE(enum_contains(Numbers::many));
     REQUIRE_FALSE(enum_contains(static_cast<Numbers>(0)));
 
@@ -317,8 +321,8 @@ TEST_CASE("enum_contains") {
 
     constexpr auto no = enum_integer(Numbers::one);
     REQUIRE(enum_contains<Numbers>(no));
-    REQUIRE(enum_contains<Numbers>(enum_integer(Numbers::two)));
     REQUIRE(enum_contains<Numbers>(enum_integer(Numbers::three)));
+    REQUIRE_FALSE(enum_contains<Numbers>(enum_integer(Numbers::two)));
     REQUIRE_FALSE(enum_contains<Numbers>(enum_integer(Numbers::many)));
 
     constexpr auto dr = enum_integer(Directions::Right);
@@ -356,8 +360,8 @@ TEST_CASE("enum_contains") {
 
     constexpr auto no = std::string_view{"one"};
     REQUIRE(enum_contains<Numbers>(no));
-    REQUIRE(enum_contains<Numbers>("two"));
     REQUIRE(enum_contains<Numbers>("three"));
+    REQUIRE_FALSE(enum_contains<Numbers>("two"));
     REQUIRE_FALSE(enum_contains<Numbers>("many"));
     REQUIRE_FALSE(enum_contains<Numbers>("None"));
 
@@ -398,12 +402,10 @@ TEST_CASE("enum_value") {
 
   constexpr auto no = enum_value<Numbers>(0);
   REQUIRE(no == Numbers::one);
-  REQUIRE(enum_value<Numbers>(1) == Numbers::two);
-  REQUIRE(enum_value<Numbers>(2) == Numbers::three);
+  REQUIRE(enum_value<Numbers>(1) == Numbers::three);
 
   REQUIRE(enum_value<Numbers, 0>() == Numbers::one);
-  REQUIRE(enum_value<Numbers, 1>() == Numbers::two);
-  REQUIRE(enum_value<Numbers, 2>() == Numbers::three);
+  REQUIRE(enum_value<Numbers, 1>() == Numbers::three);
 
   constexpr auto dr = enum_value<Directions>(3);
   REQUIRE(enum_value<Directions&>(0) == Directions::Left);
@@ -441,7 +443,7 @@ TEST_CASE("enum_values") {
   REQUIRE(s1 == std::array<Color, 3>{{Color::RED, Color::GREEN, Color::BLUE}});
 
   constexpr auto& s2 = enum_values<Numbers>();
-  REQUIRE(s2 == std::array<Numbers, 3>{{Numbers::one, Numbers::two, Numbers::three}});
+  REQUIRE(s2 == std::array<Numbers, 2>{{Numbers::one, Numbers::three}});
 
   constexpr auto& s3 = enum_values<const Directions>();
   REQUIRE(s3 == std::array<Directions, 4>{{Directions::Left, Directions::Down, Directions::Up, Directions::Right}});
@@ -466,7 +468,7 @@ TEST_CASE("enum_count") {
   REQUIRE(s1 == 3);
 
   constexpr auto s2 = enum_count<Numbers>();
-  REQUIRE(s2 == 3);
+  REQUIRE(s2 == 2);
 
   constexpr auto s3 = enum_count<const Directions>();
   REQUIRE(s3 == 4);
@@ -500,8 +502,8 @@ TEST_CASE("enum_name") {
     constexpr Numbers no = Numbers::one;
     constexpr auto no_name = enum_name(no);
     REQUIRE(no_name == "one");
-    REQUIRE(enum_name(Numbers::two) == "two");
     REQUIRE(enum_name(Numbers::three) == "three");
+    REQUIRE(enum_name(Numbers::two).empty());
     REQUIRE(enum_name(Numbers::many).empty());
     REQUIRE(enum_name(static_cast<Numbers>(0)).empty());
 
@@ -545,7 +547,6 @@ TEST_CASE("enum_name") {
     constexpr Numbers no = Numbers::one;
     constexpr auto no_name = enum_name<no>();
     REQUIRE(no_name == "one");
-    REQUIRE(enum_name<Numbers::two>() == "two");
     REQUIRE(enum_name<Numbers::three>() == "three");
     REQUIRE(enum_name<Numbers::many>() == "many");
 
@@ -584,7 +585,7 @@ TEST_CASE("enum_names") {
   REQUIRE(s1 == std::array<std::string_view, 3>{{"red", "GREEN", "BLUE"}});
 
   constexpr auto& s2 = enum_names<Numbers>();
-  REQUIRE(s2 == std::array<std::string_view, 3>{{"one", "two", "three"}});
+  REQUIRE(s2 == std::array<std::string_view, 2>{{"one", "three"}});
 
   constexpr auto& s3 = enum_names<const Directions>();
   REQUIRE(s3 == std::array<std::string_view, 4>{{"Left", "Down", "Up", "Right"}});
@@ -605,7 +606,7 @@ TEST_CASE("enum_entries") {
   REQUIRE(s1 == std::array<std::pair<Color, std::string_view>, 3>{{{Color::RED, "red"}, {Color::GREEN, "GREEN"}, {Color::BLUE, "BLUE"}}});
 
   constexpr auto& s2 = enum_entries<Numbers>();
-  REQUIRE(s2 == std::array<std::pair<Numbers, std::string_view>, 3>{{{Numbers::one, "one"}, {Numbers::two, "two"}, {Numbers::three, "three"}}});
+  REQUIRE(s2 == std::array<std::pair<Numbers, std::string_view>, 2>{{{Numbers::one, "one"}, {Numbers::three, "three"}}});
 
   constexpr auto& s3 = enum_entries<Directions&>();
   REQUIRE(s3 == std::array<std::pair<Directions, std::string_view>, 4>{{{Directions::Left, "Left"}, {Directions::Down, "Down"}, {Directions::Up, "Up"}, {Directions::Right, "Right"}}});
@@ -634,7 +635,7 @@ TEST_CASE("ostream_operators") {
   test_ostream(std::make_optional(static_cast<Color>(0)), "0");
 
   test_ostream(std::make_optional(Numbers::one), "one");
-  test_ostream(Numbers::two, "two");
+  test_ostream(Numbers::two, "2");
   test_ostream(Numbers::three, "three");
   test_ostream(Numbers::many, "127");
   test_ostream(static_cast<Numbers>(0), "0");

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -96,13 +96,10 @@ constexpr std::string_view magic_enum::customize::enum_name<Color>(Color value) 
 
 namespace magic_enum::customize {
 template<>
-constexpr std::string_view enum_name_v<Binary, Binary::ONE> = "1";
+constexpr std::string_view enum_name_v<Binary::ONE> = "1";
 
 template<>
-constexpr std::string_view enum_name_v<MaxUsedAsInvalid, MaxUsedAsInvalid::ONE> = "ONE";
-
-template<>
-constexpr std::string_view enum_name_v<Numbers, Numbers::two>{};
+constexpr std::string_view enum_name_v<Numbers::two>{};
 }
 
 using namespace magic_enum;

--- a/test/test_flags.cpp
+++ b/test/test_flags.cpp
@@ -86,7 +86,7 @@ struct magic_enum::customize::enum_range<number> {
 
 namespace magic_enum::customize {
 template<>
-constexpr std::string_view enum_name_v<Numbers, Numbers::all>{};
+constexpr std::string_view enum_name_v<Numbers::all>{};
 }
 
 using namespace magic_enum;

--- a/test/test_flags.cpp
+++ b/test/test_flags.cpp
@@ -46,6 +46,7 @@ enum class Numbers : int {
   two = 1 << 2,
   three = 1 << 3,
   many = 1 << 30,
+  all = one | two | three,
 };
 
 enum Directions : std::uint64_t {
@@ -82,6 +83,9 @@ struct magic_enum::customize::enum_range<number> {
   static constexpr int min = 100;
   static constexpr int max = 300;
 };
+
+template<>
+constexpr std::string_view magic_enum::customize::enum_name_v<Numbers::all>{};
 
 using namespace magic_enum;
 using namespace magic_enum::bitwise_operators;

--- a/test/test_flags.cpp
+++ b/test/test_flags.cpp
@@ -49,6 +49,8 @@ enum class Numbers : int {
   all = one | two | three,
 };
 
+constexpr auto NumberFour = static_cast<Numbers>(1 << 4);
+
 enum Directions : std::uint64_t {
   Left = std::uint64_t{1} << 10,
   Down = std::uint64_t{1} << 20,
@@ -87,6 +89,8 @@ struct magic_enum::customize::enum_range<number> {
 namespace magic_enum::customize {
 template<>
 constexpr std::string_view enum_name_v<Numbers::all>{};
+template<>
+constexpr std::string_view enum_name_v<NumberFour> = "four";
 }
 
 using namespace magic_enum;
@@ -108,6 +112,7 @@ TEST_CASE("enum_cast") {
     REQUIRE(no.value() == Numbers::one);
     REQUIRE(enum_cast<Numbers>("two").value() == Numbers::two);
     REQUIRE(enum_cast<Numbers>("three").value() == Numbers::three);
+    REQUIRE(enum_cast<Numbers>("four").value() == NumberFour);
     REQUIRE(enum_cast<Numbers>("many") == Numbers::many);
     REQUIRE_FALSE(enum_cast<Numbers>("None").has_value());
 
@@ -151,6 +156,7 @@ TEST_CASE("enum_cast") {
     REQUIRE(no.value() == Numbers::one);
     REQUIRE(enum_cast<Numbers>(4).value() == Numbers::two);
     REQUIRE(enum_cast<Numbers>(8).value() == Numbers::three);
+    REQUIRE(enum_cast<Numbers>(16).value() == NumberFour);
     REQUIRE(enum_cast<Numbers>(1 << 30).value() == Numbers::many);
     REQUIRE_FALSE(enum_cast<Numbers>(127).has_value());
     REQUIRE_FALSE(enum_cast<Numbers>(0).has_value());
@@ -197,7 +203,8 @@ TEST_CASE("enum_index") {
   REQUIRE(no.value() == 0);
   REQUIRE(enum_index(Numbers::two).value() == 1);
   REQUIRE(enum_index(Numbers::three).value() == 2);
-  REQUIRE(enum_index(Numbers::many).value() == 3);
+  REQUIRE(enum_index(NumberFour).value() == 3);
+  REQUIRE(enum_index(Numbers::many).value() == 4);
   REQUIRE_FALSE(enum_index(static_cast<Numbers>(0)).has_value());
 
   constexpr auto dr = enum_index(Directions::Right);
@@ -244,6 +251,7 @@ TEST_CASE("enum_contains") {
     REQUIRE(no);
     REQUIRE(enum_contains(Numbers::two));
     REQUIRE(enum_contains(Numbers::three));
+    REQUIRE(enum_contains(NumberFour));
     REQUIRE(enum_contains(Numbers::many));
     REQUIRE_FALSE(enum_contains(static_cast<Numbers>(0)));
 
@@ -287,6 +295,7 @@ TEST_CASE("enum_contains") {
     REQUIRE(no);
     REQUIRE(enum_contains<Numbers>(1 << 2));
     REQUIRE(enum_contains<Numbers>(1 << 3));
+    REQUIRE(enum_contains<Numbers>(1 << 4));
     REQUIRE(enum_contains<Numbers>(1 << 30));
 
     constexpr auto dr = enum_contains<Directions&>(std::uint64_t{1} << 63);
@@ -332,6 +341,7 @@ TEST_CASE("enum_contains") {
     REQUIRE(enum_contains<Numbers>(no));
     REQUIRE(enum_contains<Numbers>("two"));
     REQUIRE(enum_contains<Numbers>("three"));
+    REQUIRE(enum_contains<Numbers>("four"));
     REQUIRE(enum_contains<Numbers>("many"));
     REQUIRE_FALSE(enum_contains<Numbers>("None"));
 
@@ -375,12 +385,14 @@ TEST_CASE("enum_value") {
   REQUIRE(no == Numbers::one);
   REQUIRE(enum_value<Numbers>(1) == Numbers::two);
   REQUIRE(enum_value<Numbers>(2) == Numbers::three);
-  REQUIRE(enum_value<Numbers>(3) == Numbers::many);
+  REQUIRE(enum_value<Numbers>(3) == NumberFour);
+  REQUIRE(enum_value<Numbers>(4) == Numbers::many);
 
   REQUIRE(enum_value<Numbers, 0>() == Numbers::one);
   REQUIRE(enum_value<Numbers, 1>() == Numbers::two);
   REQUIRE(enum_value<Numbers, 2>() == Numbers::three);
-  REQUIRE(enum_value<Numbers, 3>() == Numbers::many);
+  REQUIRE(enum_value<Numbers, 3>() == NumberFour);
+  REQUIRE(enum_value<Numbers, 4>() == Numbers::many);
 
   constexpr auto dr = enum_value<Directions>(3);
   REQUIRE(enum_value<Directions&>(0) == Directions::Left);
@@ -420,7 +432,7 @@ TEST_CASE("enum_values") {
   REQUIRE(s1 == std::array<Color, 3>{{Color::RED, Color::GREEN, Color::BLUE}});
 
   constexpr auto& s2 = enum_values<Numbers>();
-  REQUIRE(s2 == std::array<Numbers, 4>{{Numbers::one, Numbers::two, Numbers::three, Numbers::many}});
+  REQUIRE(s2 == std::array<Numbers, 5>{{Numbers::one, Numbers::two, Numbers::three, NumberFour, Numbers::many}});
 
   constexpr auto& s3 = enum_values<const Directions>();
   REQUIRE(s3 == std::array<Directions, 4>{{Directions::Left, Directions::Down, Directions::Up, Directions::Right}});
@@ -439,7 +451,7 @@ TEST_CASE("enum_count") {
   REQUIRE(s1 == 3);
 
   constexpr auto s2 = enum_count<Numbers>();
-  REQUIRE(s2 == 4);
+  REQUIRE(s2 == 5);
 
   constexpr auto s3 = enum_count<const Directions>();
   REQUIRE(s3 == 4);
@@ -472,6 +484,7 @@ TEST_CASE("enum_name") {
     REQUIRE(no_name == "one");
     REQUIRE(enum_name(Numbers::two) == "two");
     REQUIRE(enum_name(Numbers::three) == "three");
+    REQUIRE(enum_name(NumberFour) == "four");
     REQUIRE(enum_name(Numbers::many) == "many");
     REQUIRE(enum_name(Numbers::many | Numbers::two).empty());
     REQUIRE(enum_name(static_cast<Numbers>(0)).empty());
@@ -526,8 +539,10 @@ TEST_CASE("enum_flags_name") {
   REQUIRE(no_name == "one");
   REQUIRE(enum_flags_name(Numbers::two) == "two");
   REQUIRE(enum_flags_name(Numbers::three) == "three");
+  REQUIRE(enum_flags_name(NumberFour) == "four");
   REQUIRE(enum_flags_name(Numbers::many) == "many");
   REQUIRE(enum_flags_name(Numbers::many | Numbers::two) == "two|many");
+  REQUIRE(enum_flags_name(Numbers::three | NumberFour) == "three|four");
   REQUIRE(enum_flags_name(static_cast<Numbers>(0)).empty());
 
   constexpr Directions dr = Directions::Right;
@@ -568,7 +583,7 @@ TEST_CASE("enum_names") {
   REQUIRE(s1 == std::array<std::string_view, 3>{{"RED", "GREEN", "BLUE"}});
 
   constexpr auto& s2 = enum_names<Numbers>();
-  REQUIRE(s2 == std::array<std::string_view, 4>{{"one", "two", "three", "many"}});
+  REQUIRE(s2 == std::array<std::string_view, 5>{{"one", "two", "three", "four", "many"}});
 
   constexpr auto& s3 = enum_names<const Directions>();
   REQUIRE(s3 == std::array<std::string_view, 4>{{"Left", "Down", "Up", "Right"}});
@@ -589,7 +604,7 @@ TEST_CASE("enum_entries") {
   REQUIRE(s1 == std::array<std::pair<Color, std::string_view>, 3>{{{Color::RED, "RED"}, {Color::GREEN, "GREEN"}, {Color::BLUE, "BLUE"}}});
 
   constexpr auto& s2 = enum_entries<Numbers>();
-  REQUIRE(s2 == std::array<std::pair<Numbers, std::string_view>, 4>{{{Numbers::one, "one"}, {Numbers::two, "two"}, {Numbers::three, "three"}, {Numbers::many, "many"}}});
+  REQUIRE(s2 == std::array<std::pair<Numbers, std::string_view>, 5>{{{Numbers::one, "one"}, {Numbers::two, "two"}, {Numbers::three, "three"}, {NumberFour, "four"}, {Numbers::many, "many"}}});
 
   constexpr auto& s3 = enum_entries<Directions&>();
   REQUIRE(s3 == std::array<std::pair<Directions, std::string_view>, 4>{{{Directions::Left, "Left"}, {Directions::Down, "Down"}, {Directions::Up, "Up"}, {Directions::Right, "Right"}}});
@@ -622,6 +637,7 @@ TEST_CASE("ostream_operators") {
   test_ostream(std::make_optional(Numbers::one), "one");
   test_ostream(Numbers::two, "two");
   test_ostream(Numbers::three, "three");
+  test_ostream(NumberFour, "four");
   test_ostream(Numbers::many, "many");
   test_ostream(static_cast<Numbers>(0), "0");
   test_ostream(std::make_optional(static_cast<Numbers>(0)), "0");

--- a/test/test_flags.cpp
+++ b/test/test_flags.cpp
@@ -86,7 +86,7 @@ struct magic_enum::customize::enum_range<number> {
 
 namespace magic_enum::customize {
 template<>
-constexpr std::string_view enum_name_v<Numbers::all>{};
+constexpr std::string_view enum_name_v<Numbers, Numbers::all>{};
 }
 
 using namespace magic_enum;

--- a/test/test_flags.cpp
+++ b/test/test_flags.cpp
@@ -84,8 +84,10 @@ struct magic_enum::customize::enum_range<number> {
   static constexpr int max = 300;
 };
 
+namespace magic_enum::customize {
 template<>
-constexpr std::string_view magic_enum::customize::enum_name_v<Numbers::all>{};
+constexpr std::string_view enum_name_v<Numbers::all>{};
+}
 
 using namespace magic_enum;
 using namespace magic_enum::bitwise_operators;


### PR DESCRIPTION
If someone needs to change only one enum instance name, it is much easier with this modification.

With this, it is not necessary to write a function but enough a constant variable.

So
```
template <>
constexpr std::string_view magic_enum::customize::enum_name<Color>(Color value) noexcept {
  switch (value) {
    case Color::RED:
      return "red";
    default:
      return {};
  }
}
```

can be simplified to
```
template<>
constexpr std::string_view magic_enum::customize::enum_name_v<Color, Color::RED> = "red";
```

--- 

reorder `enum_name_v`, move to `customize::` + add test