### PR TITLE
Add C++17 requirements in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ target_include_directories(${PROJECT_NAME}
         INTERFACE
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:include>)
+            
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
 
 write_basic_package_version_file(${PROJECT_NAME}ConfigVersion.cmake
         VERSION ${PROJECT_VERSION}


### PR DESCRIPTION
Explicitly specify that this package requires c++17 language features.

After this change, building this package using a toolchain configured with a default cpp standard before 17, cmake understands that it should compile using cpp17.