### PR TITLE
make streams and exceptions optional

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -40,7 +40,6 @@
 #include <cassert>
 #include <cstdint>
 #include <cstddef>
-#include <iosfwd>
 #include <limits>
 #include <type_traits>
 #include <utility>
@@ -58,6 +57,9 @@
 #endif
 #if !defined(MAGIC_ENUM_USING_ALIAS_STRING_VIEW)
 #include <string_view>
+#endif
+#if !defined(MAGIC_ENUM_NO_STREAMS)
+#include <iosfwd>
 #endif
 
 #if defined(__clang__)
@@ -1381,6 +1383,8 @@ constexpr auto enum_for_each(Lambda&& lambda) {
   }
 }
 
+#if !defined(MAGIC_ENUM_NO_STREAMS)
+
 namespace ostream_operators {
 
 template <typename Char, typename Traits, typename E, detail::enable_if_t<E, int> = 0>
@@ -1430,6 +1434,8 @@ using namespace ostream_operators;
 using namespace istream_operators;
 
 } // namespace magic_enum::iostream_operators
+
+#endif
 
 namespace bitwise_operators {
 

--- a/include/magic_enum_format.hpp
+++ b/include/magic_enum_format.hpp
@@ -43,8 +43,14 @@
 #  define MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT_AUTO_DEFINE
 #endif // MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT
 
+#if !defined(MAGIC_ENUM_NO_EXCEPTIONS) && (defined(__cpp_exceptions) || defined(_EXCEPTIONS) || defined(_HAS_EXCEPTIONS))
+#  define MAGIC_ENUM_THROW throw std::format_error
+#else
+#  define MAGIC_ENUM_THROW std::terminate(); (void)
+#endif
+
 namespace magic_enum::customize {
-  // customize enum to enable/disable automatic std::format 
+  // customize enum to enable/disable automatic std::format
   template <typename E>
   constexpr bool enum_format_enabled() noexcept {
     return MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT;
@@ -67,7 +73,7 @@ struct std::formatter<E, std::enable_if_t<std::is_enum_v<E> && magic_enum::custo
       }
     }
     constexpr auto type_name = magic_enum::enum_type_name<E>();
-    throw std::format_error("Type of " + std::string{type_name.data(), type_name.size()} + " enum value: " + std::to_string(magic_enum::enum_integer<D>(e)) + " is not exists.");
+    MAGIC_ENUM_THROW("Type of " + std::string{type_name.data(), type_name.size()} + " enum value: " + std::to_string(magic_enum::enum_integer<D>(e)) + " is not exists.");
   }
 };
 


### PR DESCRIPTION
This pr adds support to disable streams and exceptions with macros:
```c++
MAGIC_ENUM_NO_EXCEPTIONS
MAGIC_ENUM_NO_STREAMS
```