### PR TITLE
Speed up constexpr evaluation

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -251,27 +251,34 @@ class static_string<0> {
 };
 
 constexpr string_view pretty_name(string_view name) noexcept {
+  char const* str = name.data();
   for (std::size_t i = name.size(); i > 0; --i) {
-    if (!((name[i - 1] >= '0' && name[i - 1] <= '9') ||
-          (name[i - 1] >= 'a' && name[i - 1] <= 'z') ||
-          (name[i - 1] >= 'A' && name[i - 1] <= 'Z') ||
+    char c = str[i - 1];
+    if (!((c >= '0' && c <= '9') ||
+          (c >= 'a' && c <= 'z') ||
+          (c >= 'A' && c <= 'Z') ||
 #if defined(MAGIC_ENUM_ENABLE_NONASCII)
-          (name[i - 1] & 0x80) ||
+          (c & 0x80) ||
 #endif
-          (name[i - 1] == '_'))) {
+          (c == '_'))) {
       name.remove_prefix(i);
       break;
     }
   }
 
-  if (name.size() > 0 && ((name[0] >= 'a' && name[0] <= 'z') ||
-                          (name[0] >= 'A' && name[0] <= 'Z') ||
+  if (name.size() > 0)
+  {
+      char c = name[0];
+    if ((c >= 'a' && c <= 'z') ||
+        (c >= 'A' && c <= 'Z') ||
 #if defined(MAGIC_ENUM_ENABLE_NONASCII)
-                          (name[0]) & 0x80) ||
+        (c) & 0x80) ||
 #endif
-                          (name[0] == '_'))) {
-    return name;
+        (c == '_')) {
+      return name;
+    }
   }
+  
   return {}; // Invalid name.
 }
 


### PR DESCRIPTION
The `pretty_name` function is called very frequently during the compilation, and with a modified clang I've noticed that this function can be slightly changed to speed up compilation. On my machine build time for `example.cpp` was reduced from 2.4s to 1.9s (-20%) with this change. Doesn't look like much, but this would save time for each unique enum used in the translation unit

Clang traces for the reference (can be viewed in [Perfetto](https://ui.perfetto.dev/)):
Before: [example.cpp-before.json.zip](https://github.com/Neargye/magic_enum/files/10254850/example.cpp-before.json.zip)
After: [example.cpp-after.json.zip](https://github.com/Neargye/magic_enum/files/10254848/example.cpp-after.json.zip)

Future ideas for further improvements:
* `std::string_view` seems to have a big overhead when being evaluated during the compilation (due to sanity checks at least on MSVC), so using a very simple custom string view class internally might be of help, preferably as a struct without member functions. In my project it reduced compilation time by another 30%
* I've experimented with a single function instantiation with a pack of N template value arguments (instead of N function instantiations with 1 template value argument each, where N is `max - min + 1`), and that resulted in a faster compilation in my case, so it's also something to consider (although this might be a very big change)