### PR TITLE
Fix Clang 16 build in GitHub Actions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -36,6 +36,7 @@ jobs:
           sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main"
           sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main"
           sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-15 main"
+          sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-16 main"
           sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main"
           sudo apt update
           sudo apt install ${{matrix.compiler.cc}} -y


### PR DESCRIPTION
The build for Clang 16 on Ubuntu is currently failing, see for example https://github.com/Neargye/magic_enum/actions/runs/4054633442/jobs/6976700211. The reason for that is a missing APT package repository for Clang 16 packages, so no `clang-16` package can be installed.

This pull requests adds the APT package repository for Clang 16 to fix that problem.