### PR TITLE
added -std=c++17 to flags so clangd would identify c++17 headers properly

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,5 +1,6 @@
 include(CheckCXXCompilerFlag)
 
+set(CMAKE_CXX_STANDARD 17)
 if((CMAKE_CXX_COMPILER_ID MATCHES "GNU") OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
     set(OPTIONS -Wall -Wextra -pedantic-errors -Werror)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")


### PR DESCRIPTION
I was having an issue where clangd would not properly see c++17 header files for magic_enum examples only. Clangd had no problem sorting through headers of files that were compiled with -std=c++17. Here's what I mean (from example/example.cpp):

![image](https://user-images.githubusercontent.com/33668314/217993219-2de3f99b-a97e-4ddf-93b3-dd46082f803a.png)

This PR fixes that. This may be a change that doesn't need to happen, but I thought I would make the pr just in case.