### PR TITLE
Fix std::forward variadic arguments in invoke_deoptimized()

### DIFF
--- a/test/3rdparty/Catch2/include/catch2/catch.hpp
+++ b/test/3rdparty/Catch2/include/catch2/catch.hpp
@@ -6516,12 +6516,12 @@ namespace Catch {
 
         template <typename Fn, typename... Args>
         inline auto invoke_deoptimized(Fn&& fn, Args&&... args) -> typename std::enable_if<!std::is_same<void, decltype(fn(args...))>::value>::type {
-            deoptimize_value(std::forward<Fn>(fn) (std::forward<Args...>(args...)));
+            deoptimize_value(std::forward<Fn>(fn) (std::forward<Args>(args)...));
         }
 
         template <typename Fn, typename... Args>
         inline auto invoke_deoptimized(Fn&& fn, Args&&... args) -> typename std::enable_if<std::is_same<void, decltype(fn(args...))>::value>::type {
-            std::forward<Fn>(fn) (std::forward<Args...>(args...));
+            std::forward<Fn>(fn) (std::forward<Args>(args)...);
         }
     } // namespace Benchmark
 } // namespace Catch


### PR DESCRIPTION
Small fix. 
`std::forward<Args...>(args...)` is specialized to smth like `std::forward<Args_1, Args_2, ...>(args_1, args_2,...)`. But `std::forward` accepts only one argument.