### PR TITLE
meson: add options and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [![Conan package](https://img.shields.io/badge/Conan-package-blueviolet)](https://conan.io/center/magic_enum)
 [![Vcpkg package](https://img.shields.io/badge/Vcpkg-package-blueviolet)](https://github.com/microsoft/vcpkg/tree/master/ports/magic-enum)
 [![Build2 package](https://img.shields.io/badge/Build2-package-blueviolet)](https://www.cppget.org/magic_enum?q=magic_enum)
+[![Meson wrap](https://img.shields.io/badge/Meson-wrap-blueviolet)](https://github.com/mesonbuild/wrapdb/blob/master/subprojects/magic_enum.wrap)
 [![License](https://img.shields.io/github/license/Neargye/magic_enum.svg)](LICENSE)
 [![Try online](https://img.shields.io/badge/try-online-blue.svg)](https://wandbox.org/permlink/JPMZqT9mgaUdooyC)
 [![Compiler explorer](https://img.shields.io/badge/compiler_explorer-online-blue.svg)](https://godbolt.org/z/BxfmsH)

--- a/meson.build
+++ b/meson.build
@@ -20,3 +20,7 @@ magic_enum_dep = declare_dependency(
     include_directories: magic_enum_include,
     compile_args: magic_enum_args,
 )
+
+if get_option('test')
+    subdir('test')
+endif

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,17 @@ project(
 
 magic_enum_include = include_directories('include')
 
+magic_enum_args = []
+
+if get_option('noascii')
+    magic_enum_args += '-DMAGIC_ENUM_ENABLE_NONASCII'
+endif
+
+if get_option('hash')
+    magic_enum_args += '-DMAGIC_ENUM_ENABLE_HASH'
+endif
+
 magic_enum_dep = declare_dependency(
     include_directories: magic_enum_include,
+    compile_args: magic_enum_args,
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,11 @@
 option(
+    'test',
+    type : 'boolean',
+    value : true,
+    description : 'Build and run tests'
+)
+
+option(
     'noascii',
     type : 'boolean',
     value : false,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,13 @@
+option(
+    'noascii',
+    type : 'boolean',
+    value : false,
+    description : 'Enable support for non-ASCII enumeration identifier'
+)
+
+option(
+    'hash',
+    type : 'boolean',
+    value : false,
+    description : 'Do hashing at build time - longer build times, but O(1) string lookup'
+)

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,21 @@
+catch2_dep = declare_dependency(
+    include_directories: '3rdparty/Catch2'
+)
+
+test_files = {
+    'basic test'      : files('test.cpp'),
+    'flags test'      : files('test_flags.cpp'),
+    'aliases test'    : files('test_aliases.cpp'),
+    'containers test' : files('test_containers.cpp'),
+}
+
+foreach test_name, test_src : test_files
+    test_exe = executable(
+        test_name.underscorify(),
+        test_src,
+
+        dependencies: [magic_enum_dep, catch2_dep]
+    )
+
+    test(test_name, test_exe)
+endforeach


### PR DESCRIPTION
Allows to enable flags from meson instead of relying on defines. Also support building/running tests from meson.