### PR TITLE
Support gcc -fno-pretty-templates

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -266,6 +266,13 @@ class static_string<0> {
 
 constexpr string_view pretty_name(string_view name) noexcept {
   const char* str = name.data();
+#if defined(__clang__) // ]
+  name.remove_suffix(1);
+#elif defined(__GNUC__) // ] or >() (-fno-pretty-templates)
+  name.remove_suffix(name[name.size() - 1] == ']' ? 1 : 3);
+#elif defined(_MSC_VER) // >(void) noexcept
+  name.remove_suffix(16);
+#endif
   for (std::size_t i = name.size(); i > 0; --i) {
     const char c = str[i - 1];
     if (!((c >= '0' && c <= '9') ||
@@ -426,9 +433,9 @@ constexpr auto n() noexcept {
     constexpr auto name_ptr = MAGIC_ENUM_GET_TYPE_NAME_BUILTIN(E);
     constexpr auto name = name_ptr ? string_view{ name_ptr } : std::string_view{};
 #elif defined(__clang__) || defined(__GNUC__)
-    constexpr auto name = pretty_name({__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 2});
+    constexpr auto name = pretty_name({__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 1});
 #elif defined(_MSC_VER)
-    constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 17});
+    constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 1});
 #else
     constexpr auto name = string_view{};
 #endif
@@ -470,9 +477,9 @@ constexpr auto n() noexcept {
     constexpr auto name_ptr = MAGIC_ENUM_GET_ENUM_NAME_BUILTIN(V);
     constexpr auto name = name_ptr ? string_view{ name_ptr } : std::string_view{};
 #elif defined(__clang__) || defined(__GNUC__)
-    constexpr auto name = pretty_name({__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 2});
+    constexpr auto name = pretty_name({__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 1});
 #elif defined(_MSC_VER)
-    constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 17});
+    constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 1});
 #else
     constexpr auto name = string_view{};
 #endif

--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -266,13 +266,6 @@ class static_string<0> {
 
 constexpr string_view pretty_name(string_view name) noexcept {
   const char* str = name.data();
-#if defined(__clang__) // ]
-  name.remove_suffix(1);
-#elif defined(__GNUC__) // ] or >() (-fno-pretty-templates)
-  name.remove_suffix(name[name.size() - 1] == ']' ? 1 : 3);
-#elif defined(_MSC_VER) // >(void) noexcept
-  name.remove_suffix(16);
-#endif
   for (std::size_t i = name.size(); i > 0; --i) {
     const char c = str[i - 1];
     if (!((c >= '0' && c <= '9') ||
@@ -432,10 +425,14 @@ constexpr auto n() noexcept {
 #if defined(MAGIC_ENUM_GET_TYPE_NAME_BUILTIN)
     constexpr auto name_ptr = MAGIC_ENUM_GET_TYPE_NAME_BUILTIN(E);
     constexpr auto name = name_ptr ? string_view{ name_ptr } : std::string_view{};
-#elif defined(__clang__) || defined(__GNUC__)
-    constexpr auto name = pretty_name({__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 1});
+#elif defined(__clang__)
+    constexpr auto name = pretty_name({__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 2});
+#elif defined(__GNUC__)
+    auto name = string_view{__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 1};
+    name.remove_suffix(name[name.size() - 1] == ']' ? 1 : 3);
+    name = pretty_name(name);
 #elif defined(_MSC_VER)
-    constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 1});
+    constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 17});
 #else
     constexpr auto name = string_view{};
 #endif
@@ -476,10 +473,14 @@ constexpr auto n() noexcept {
 #if defined(MAGIC_ENUM_GET_ENUM_NAME_BUILTIN)
     constexpr auto name_ptr = MAGIC_ENUM_GET_ENUM_NAME_BUILTIN(V);
     constexpr auto name = name_ptr ? string_view{ name_ptr } : std::string_view{};
-#elif defined(__clang__) || defined(__GNUC__)
-    constexpr auto name = pretty_name({__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 1});
+#elif defined(__clang__)
+    constexpr auto name = pretty_name({__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 2});
+#elif defined(__GNUC__)
+    auto name = string_view{__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 1};
+    name.remove_suffix(name[name.size() - 1] == ']' ? 1 : 3);
+    name = pretty_name(name);
 #elif defined(_MSC_VER)
-    constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 1});
+    constexpr auto name = pretty_name({__FUNCSIG__, sizeof(__FUNCSIG__) - 17});
 #else
     constexpr auto name = string_view{};
 #endif

--- a/test/test_aliases.cpp
+++ b/test/test_aliases.cpp
@@ -76,6 +76,7 @@ struct MyStringView {
   constexpr std::size_t find(char c) const { return str.find(c); } // required
   constexpr MyStringView substr(std::size_t p, std::size_t n) { return str.substr(p, n); } // required
   constexpr void remove_prefix(std::size_t n) { str.remove_prefix(n); } // required
+  constexpr void remove_suffix(std::size_t n) { str.remove_suffix(n); } // required
   friend constexpr bool operator==(MyStringView lhs, MyStringView rhs); // required
 
   constexpr MyStringView(const char* cstr) : str{ cstr } {}


### PR DESCRIPTION
The gcc option [-fno-pretty-templates](https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html#index-fno-pretty-templates
) changes the `__PRETTY_FUNCTION__` from e.g. `"auto n() [with E = E]"` to `"auto n<E>()"` (a bit more like MSVC). Demo: https://godbolt.org/z/dj86T77b9

Construct a string_view from `__PRETTY_FUNCTION__` , and inspect the last character to determine how much to truncate before passing to `pretty_name`.