### PR TITLE
Add const to std::formatter method

### DIFF
--- a/include/magic_enum_format.hpp
+++ b/include/magic_enum_format.hpp
@@ -55,7 +55,7 @@ namespace magic_enum::customize {
 
 template <typename E>
 struct std::formatter<E, std::enable_if_t<std::is_enum_v<E> && magic_enum::customize::enum_format_enabled<E>(), char>> : std::formatter<std::string_view, char> {
-  auto format(E e, format_context& ctx) {
+  auto format(E e, format_context& ctx) const {
     static_assert(std::is_same_v<char, string_view::value_type>, "formatter requires string_view::value_type type same as char.");
     using D = std::decay_t<E>;
 


### PR DESCRIPTION
The tests failed to build on gcc 13 without this const