### PR TITLE
Fixed meson build for tests

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -1,10 +1,8 @@
-catch2_dep = declare_dependency(
-    include_directories: '3rdparty/Catch2'
-)
+catch2_dep = declare_dependency(include_directories: '3rdparty/Catch2/include')
 
 test_files = {
-    'basic test'      : files('test.cpp'),
-    'flags test'      : files('test_flags.cpp'),
+    'basic test': files('test.cpp'),
+    'flags test': files('test_flags.cpp'),
 }
 
 foreach test_name, test_src : test_files
@@ -12,7 +10,7 @@ foreach test_name, test_src : test_files
         test_name.underscorify(),
         test_src,
 
-        dependencies: [magic_enum_dep, catch2_dep]
+        dependencies: [magic_enum_dep, catch2_dep],
     )
 
     test(test_name, test_exe)


### PR DESCRIPTION
The include path for catch2 was incorrect in `test/meson.build`. This was also formatted by the muon formatter, which I can revert if it's a problem.