### PR TITLE
meson_options.txt: remove leftover noascii option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,13 +6,6 @@ option(
 )
 
 option(
-    'noascii',
-    type : 'boolean',
-    value : false,
-    description : 'Enable support for non-ASCII enumeration identifier'
-)
-
-option(
     'hash',
     type : 'boolean',
     value : false,


### PR DESCRIPTION
Seems like this file was overlooked when purging noascii option from project.

I've also considered adding an option for recently introduced `MAGIC_ENUM_AUTO_IS_FLAGS`, but I'm not sure. If it's purely for compatibility reasons then it's probably not worth adding (and it's not exposed in CMake either). Would like to hear your opinion on this.