### PR TITLE
Explicitly mark the result of detail::names as constexpr

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -827,7 +827,8 @@ inline constexpr auto max_v = (count_v<E, S> > 0) ? static_cast<U>(values_v<E, S
 
 template <typename E, enum_subtype S, std::size_t... I>
 constexpr auto names(std::index_sequence<I...>) noexcept {
-  return std::array<string_view, sizeof...(I)>{{enum_name_v<E, values_v<E, S>[I]>...}};
+    constexpr auto result = std::array<string_view, sizeof...(I)>{{enum_name_v<E, values_v<E, S>[I]>...}};
+    return result;
 }
 
 template <typename E, enum_subtype S>

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -510,6 +510,11 @@ class a_foo2 {
 };
 } // namespace
 
+enum class LargeNumbers {
+    First = -1024,
+    Second = 1024
+};
+
 TEST_CASE("enum_name") {
   SECTION("automatic storage") {
     constexpr Color cr = Color::RED;
@@ -645,6 +650,13 @@ TEST_CASE("enum_name") {
 
     REQUIRE(enum_name<Binary::ONE>() == "ONE");
     REQUIRE(enum_name<MaxUsedAsInvalid::ONE>() == "ONE");
+  }
+
+  SECTION("empty if the value is out of range") {
+    const auto ln_value = GENERATE(LargeNumbers::First, LargeNumbers::Second);
+    const auto ln_name = enum_name(ln_value);
+
+    REQUIRE(ln_name.empty());
   }
 }
 


### PR DESCRIPTION
It might make no sense, but on MSVC it can generate a compile-time error, especially if an enumerator's value is out of range. However, it compiles fine with clang on Mac, Linux, and Windows. Ditto for GCC on Linux. It seems that only MSVC on Windows causes the issue.
If there are other fixes for this issue I'd be happy to have them instead of this one :)

Example:
```
[39/44] Building CXX object test\CMakeFiles\test-cpp20.dir\test.cpp.obj
FAILED: test/CMakeFiles/test-cpp20.dir/test.cpp.obj 
C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1436~1.325\bin\Hostx64\x64\cl.exe  /nologo /TP  -IC:\Users\Vitaly\CLionProjects\magic_enum\test\3rdparty\Catch2\include -IC:\Users\Vitaly\CLionProjects\magic_enum\include /DWIN32 /D_WINDOWS /W3 /GR /EHsc /MDd /Zi /Ob0 /Od /RTC1 /W4 /WX /permissive- /std:c++20 /showIncludes /Fotest\CMakeFiles\test-cpp20.dir\test.cpp.obj /Fdtest\CMakeFiles\test-cpp20.dir\ /FS -c C:\Users\Vitaly\CLionProjects\magic_enum\test\test.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
C:\Users\Vitaly\CLionProjects\magic_enum\include\magic_enum.hpp(834): error C3615: constexpr function 'magic_enum::detail::names' cannot result in a constant expression
C:\Users\Vitaly\CLionProjects\magic_enum\include\magic_enum.hpp(834): note: failure was caused by call of undefined function or one not declared 'constexpr'
C:\Users\Vitaly\CLionProjects\magic_enum\include\magic_enum.hpp(834): note: see usage of '__builtin_array_init_helper'
C:\Users\Vitaly\CLionProjects\magic_enum\include\magic_enum.hpp(834): note: the call stack of the evaluation (the oldest call first) is
C:\Users\Vitaly\CLionProjects\magic_enum\include\magic_enum.hpp(834): note: while evaluating function 'std::array<std::string_view,0> magic_enum::detail::names<D,magic_enum::detail::enum_subtype::common,>(std::integer_sequence<size_t>) noexcept'
C:\Users\Vitaly\CLionProjects\magic_enum\include\magic_enum.hpp(1284): note: see reference to variable template 'const std::array<std::string_view,0> names_v<enum MyFoo,0>' being compiled
C:\Users\Vitaly\CLionProjects\magic_enum\test\test.cpp(520): note: see reference to function template instantiation 'std::basic_string_view<char,std::char_traits<char>> magic_enum::enum_name<MyFoo,magic_enum::detail::enum_subtype::common>(E) noexcept' being compiled
        with
        [
            E=MyFoo
        ]
[40/44] Building CXX object test\CMakeFiles\test-cpp17.dir\test.cpp.obj
cl : Command line warning D9025 : overriding '/W3' with '/W4'
[41/44] Building CXX object test\CMakeFiles\test-cpplatest.dir\test.cpp.obj
FAILED: test/CMakeFiles/test-cpplatest.dir/test.cpp.obj 
C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1436~1.325\bin\Hostx64\x64\cl.exe  /nologo /TP  -IC:\Users\Vitaly\CLionProjects\magic_enum\test\3rdparty\Catch2\include -IC:\Users\Vitaly\CLionProjects\magic_enum\include /DWIN32 /D_WINDOWS /W3 /GR /EHsc /MDd /Zi /Ob0 /Od /RTC1 /W4 /WX /permissive- /std:c++latest /showIncludes /Fotest\CMakeFiles\test-cpplatest.dir\test.cpp.obj /Fdtest\CMakeFiles\test-cpplatest.dir\ /FS -c C:\Users\Vitaly\CLionProjects\magic_enum\test\test.cpp
cl : Command line warning D9025 : overriding '/W3' with '/W4'
C:\Users\Vitaly\CLionProjects\magic_enum\include\magic_enum.hpp(834): error C3615: constexpr function 'magic_enum::detail::names' cannot result in a constant expression
C:\Users\Vitaly\CLionProjects\magic_enum\include\magic_enum.hpp(834): note: failure was caused by call of undefined function or one not declared 'constexpr'
C:\Users\Vitaly\CLionProjects\magic_enum\include\magic_enum.hpp(834): note: see usage of '__builtin_array_init_helper'
C:\Users\Vitaly\CLionProjects\magic_enum\include\magic_enum.hpp(834): note: the call stack of the evaluation (the oldest call first) is
C:\Users\Vitaly\CLionProjects\magic_enum\include\magic_enum.hpp(834): note: while evaluating function 'std::array<std::string_view,0> magic_enum::detail::names<D,magic_enum::detail::enum_subtype::common,>(std::integer_sequence<size_t>) noexcept'
C:\Users\Vitaly\CLionProjects\magic_enum\include\magic_enum.hpp(1284): note: see reference to variable template 'const std::array<std::string_view,0> names_v<enum MyFoo,0>' being compiled
C:\Users\Vitaly\CLionProjects\magic_enum\test\test.cpp(520): note: see reference to function template instantiation 'std::basic_string_view<char,std::char_traits<char>> magic_enum::enum_name<MyFoo,magic_enum::detail::enum_subtype::common>(E) noexcept' being compiled
        with
```