### PR TITLE
fixes 'std::ptrdiff_t' to 'std::size_t' casting error and suppresses `-Wuseless-cast` warning for gcc and clang

### DIFF
--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -69,9 +69,11 @@
 #  pragma clang diagnostic push
 #  pragma clang diagnostic ignored "-Wunknown-warning-option"
 #  pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
+#  pragma clang diagnostic ignored "-Wuseless-cast" // suppresses 'static_cast<char_type>('\0')' for char_type = char (common on Linux).
 #elif defined(__GNUC__)
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wmaybe-uninitialized" // May be used uninitialized 'return {};'.
+#  pragma GCC diagnostic ignored "-Wuseless-cast" // suppresses 'static_cast<char_type>('\0')' for char_type = char (common on Linux).
 #elif defined(_MSC_VER)
 #  pragma warning(push)
 #  pragma warning(disable : 26495) // Variable 'static_str<N>::chars_' is uninitialized.

--- a/include/magic_enum_utility.hpp
+++ b/include/magic_enum_utility.hpp
@@ -84,7 +84,7 @@ template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
   if (const auto i = enum_index<D, S>(value)) {
     const std::ptrdiff_t index = (static_cast<std::ptrdiff_t>(*i) + n);
     if (index >= 0 && index < count) {
-      return enum_value<D, S>(index);
+      return enum_value<D, S>(static_cast<std::size_t>(index));
     }
   }
   return {};
@@ -98,7 +98,7 @@ template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
   if (const auto i = enum_index<D, S>(value)) {
     const std::ptrdiff_t index = ((((static_cast<std::ptrdiff_t>(*i) + n) % count) + count) % count);
     if (index >= 0 && index < count) {
-      return enum_value<D, S>(index);
+      return enum_value<D, S>(static_cast<std::size_t>(index));
     }
   }
   return MAGIC_ENUM_ASSERT(false), value;
@@ -112,7 +112,7 @@ template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
   if (const auto i = enum_index<D, S>(value)) {
     const std::ptrdiff_t index = (static_cast<std::ptrdiff_t>(*i) - n);
     if (index >= 0 && index < count) {
-      return enum_value<D, S>(index);
+      return enum_value<D, S>(static_cast<std::size_t>(index));
     }
   }
   return {};
@@ -126,7 +126,7 @@ template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
   if (const auto i = enum_index<D, S>(value)) {
     const std::ptrdiff_t index = ((((static_cast<std::ptrdiff_t>(*i) - n) % count) + count) % count);
     if (index >= 0 && index < count) {
-      return enum_value<D, S>(index);
+      return enum_value<D, S>(static_cast<std::size_t>(index));
     }
   }
   return MAGIC_ENUM_ASSERT(false), value;


### PR DESCRIPTION
Thanks for the great library! :+1: 

We use this in our project, using compiler warnings and static-code analysis extensively. I didn't want to suppress all magic_enum warnings on the project level, but I thought of contributing some of the easy fixes:

### fixes 'std::ptrdiff_t' to 'std::size_t' casting error

Addresses this compiler warning:

```text
[..]/magic_enum_utility.hpp:101:31: warning: conversion to ‘std::size_t’ {aka ‘long unsigned int’} from ‘std::ptrdiff_t’ {aka ‘long int’} may change the sign of the result [-Wsign-conversion]
  101 |       return enum_value<D, S>(index);
      |                               ^~~~~
```

### suppresses `-Wuseless-cast` for static_cast<char_type>('\0')

Needed in case 'char_type' is 'char' (common on Linux but rare on Windows?)

```text
[..]/magic_enum.hpp:275:114: warning: useless cast to type ‘using magic_enum::char_type = using std::basic_string_view<char>::value_type = char’ {aka ‘char’} [-Wuseless-cast]
  275 |   constexpr static_str(string_view str, std::integer_sequence<std::uint16_t, I...>) noexcept : chars_{str[I]..., static_cast<char_type>('\0')} {}
      |                                                                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Hope this helps and meets your coding standards.

*Question aside: would you be willing to introduce compiler warning flags and static code analysis tools?*