### PR TITLE
Fix magic_enum::containers::set erase function for Clang compilers

### DIFF
--- a/include/magic_enum/magic_enum_containers.hpp
+++ b/include/magic_enum/magic_enum_containers.hpp
@@ -982,7 +982,7 @@ class set {
 
   constexpr size_type erase(const key_type& key) noexcept {
     typename container_type::reference ref = a[key];
-    bool res = ref;
+    bool res = static_cast<bool>(ref);
     if (res) {
       --s;
     }

--- a/test/test_containers.cpp
+++ b/test/test_containers.cpp
@@ -270,6 +270,12 @@ TEST_CASE("containers_set") {
   REQUIRE_FALSE(color_set.empty());
   REQUIRE(color_set.size() == 3);
   REQUIRE(magic_enum::enum_count<Color>() == color_set.size());
+  color_set.erase(Color::RED);
+  color_set.erase(Color::GREEN);
+  REQUIRE(magic_enum::enum_count<Color>() - 2 == color_set.size());
+  REQUIRE(color_set.count(Color::RED) == 0);
+  REQUIRE_FALSE(color_set.contains(Color::GREEN));
+  REQUIRE(color_set.contains(Color::BLUE));
 
   auto color_set_compare = magic_enum::containers::set<Color>();
   color_set_compare.insert(Color::BLUE);


### PR DESCRIPTION
The erase function does not compile on the following:
```
clang version 10.0.0-4ubuntu1 
Target: x86_64-pc-linux-gnu
Thread model: posix
```
When building for C++ 17 and 20 (note these specific configurations are all I tested).

Compile error:
```
include/magic_enum_containers.hpp:985:10: error: no viable conversion from 'typename container_type::reference' (aka 'reference_impl<>') to 'bool'
    bool res = ref;
         ^     ~~~
(retracted): note: in instantiation of member function 'magic_enum::containers::set<Retracted>::erase' requested here
        set.erase(Retracted::ELEMENT);
                         ^
include/magic_enum_containers.hpp:526:38: note: explicit conversion function is not a candidate
    [[nodiscard]] constexpr explicit operator bool() const noexcept { return (parent->a[num_index] & bit_index) > 0; }
```

This PR fixes that, while adding tests for this function to ensure this template is instansiated and exercised.