### PR TITLE
Fix undefined behavior (`get` is moved to `magic_enum::containers`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Header-only C++17 library provides static reflection for enums, work with any en
   color_rgb_array[Color::RED] = {255, 0, 0};
   color_rgb_array[Color::GREEN] = {0, 255, 0};
   color_rgb_array[Color::BLUE] = {0, 0, 255};
-  std::get<Color::BLUE>(color_rgb_array) // -> RGB{0, 0, 255}
+  magic_enum::containers::get<Color::BLUE>(color_rgb_array) // -> RGB{0, 0, 255}
   ```
 
 * `containers::bitset` bitset container for enums.

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -696,7 +696,7 @@ struct array {
   color_rgb_array[Color::RED] = {255, 0, 0};
   color_rgb_array[Color::GREEN] = {0, 255, 0};
   color_rgb_array[Color::BLUE] = {0, 0, 255};
-  std::get<Color::BLUE>(color_rgb_array) // -> RGB{0, 0, 255}
+  magic_enum::containers::get<Color::BLUE>(color_rgb_array) // -> RGB{0, 0, 255}
   ```
 
 ## `containers::bitset`

--- a/example/example_containers_array.cpp
+++ b/example/example_containers_array.cpp
@@ -53,13 +53,13 @@ int main() {
 
   constexpr magic_enum::containers::array<Color, RGB> color_rgb_initializer {{{{color_max, 0, 0}, {0, color_max, 0}, {0, 0, color_max}}}};
 
-  std::cout << std::get<0>(color_rgb_initializer) << std::endl; // R=255 G=0 B=0
-  std::cout << std::get<1>(color_rgb_initializer) << std::endl; // R=0 G=255 B=0
-  std::cout << std::get<2>(color_rgb_initializer) << std::endl; // R=0 G=0 B=255
+  std::cout << magic_enum::containers::get<0>(color_rgb_initializer) << std::endl; // R=255 G=0 B=0
+  std::cout << magic_enum::containers::get<1>(color_rgb_initializer) << std::endl; // R=0 G=255 B=0
+  std::cout << magic_enum::containers::get<2>(color_rgb_initializer) << std::endl; // R=0 G=0 B=255
 
-  std::cout << std::get<Color::RED>(color_rgb_initializer) << std::endl; // R=255 G=0 B=0
-  std::cout << std::get<Color::GREEN>(color_rgb_initializer) << std::endl; // R=0 G=255 B=0
-  std::cout << std::get<Color::BLUE>(color_rgb_initializer) << std::endl; // R=0 G=0 B=255
+  std::cout << magic_enum::containers::get<Color::RED>(color_rgb_initializer) << std::endl; // R=255 G=0 B=0
+  std::cout << magic_enum::containers::get<Color::GREEN>(color_rgb_initializer) << std::endl; // R=0 G=255 B=0
+  std::cout << magic_enum::containers::get<Color::BLUE>(color_rgb_initializer) << std::endl; // R=0 G=0 B=255
 
   return 0;
 }

--- a/include/magic_enum/magic_enum_containers.hpp
+++ b/include/magic_enum/magic_enum_containers.hpp
@@ -1125,10 +1125,6 @@ class set {
 template <typename V, int = 0>
 explicit set(V starter) -> set<V>;
 
-} // namespace magic_enum::containers
-
-namespace std {
-
 template <auto I, typename E, typename V, typename Index>
 constexpr std::enable_if_t<(std::is_integral_v<decltype(I)> && I < magic_enum::enum_count<E>()), V&> get(magic_enum::containers::array<E, V, Index>& a) noexcept {
   return a.a[I];
@@ -1169,6 +1165,6 @@ constexpr std::enable_if_t<std::is_same_v<decltype(Enum), E> && magic_enum::enum
   return std::move(a[Enum]);
 }
 
-} // namespace std
+} // namespace magic_enum::containers
 
 #endif // NEARGYE_MAGIC_ENUM_CONTAINERS_HPP

--- a/test/test_containers.cpp
+++ b/test/test_containers.cpp
@@ -88,13 +88,13 @@ TEST_CASE("containers_array") {
 
   constexpr auto colors = magic_enum::enum_values<Color>();
 
-  std::ignore = std::get<0>(compare_before);
-  std::ignore = std::get<1>(compare_before);
-  std::ignore = std::get<2>(compare_before);
+  std::ignore = magic_enum::containers::get<0>(compare_before);
+  std::ignore = magic_enum::containers::get<1>(compare_before);
+  std::ignore = magic_enum::containers::get<2>(compare_before);
 
-  std::ignore = std::get<Color::RED>(compare_before);
-  std::ignore = std::get<Color::GREEN>(compare_before);
-  std::ignore = std::get<Color::BLUE>(compare_before);
+  std::ignore = magic_enum::containers::get<Color::RED>(compare_before);
+  std::ignore = magic_enum::containers::get<Color::GREEN>(compare_before);
+  std::ignore = magic_enum::containers::get<Color::BLUE>(compare_before);
 
   REQUIRE(std::make_pair(colors[0], color_rgb_container_int[colors[0]]) == std::make_pair<Color, std::uint8_t>(Color::RED, 1U));
   REQUIRE(std::make_pair(colors[1], color_rgb_container_int[colors[1]]) == std::make_pair<Color, std::uint8_t>(Color::GREEN, 4U));
@@ -107,13 +107,13 @@ TEST_CASE("containers_array") {
   constexpr magic_enum::containers::array<Color, std::uint8_t> compare_after{{1U, 2U, 4U}};
   REQUIRE(color_rgb_container_int == compare_after);
 
-  std::ignore = std::get<0>(compare_after);
-  std::ignore = std::get<1>(compare_after);
-  std::ignore = std::get<2>(compare_after);
+  std::ignore = magic_enum::containers::get<0>(compare_after);
+  std::ignore = magic_enum::containers::get<1>(compare_after);
+  std::ignore = magic_enum::containers::get<2>(compare_after);
 
-  std::ignore = std::get<Color::RED>(compare_after);
-  std::ignore = std::get<Color::GREEN>(compare_after);
-  std::ignore = std::get<Color::BLUE>(compare_after);
+  std::ignore = magic_enum::containers::get<Color::RED>(compare_after);
+  std::ignore = magic_enum::containers::get<Color::GREEN>(compare_after);
+  std::ignore = magic_enum::containers::get<Color::BLUE>(compare_after);
 
   REQUIRE(std::make_pair(colors[0], color_rgb_container_int[colors[0]]) == std::make_pair<Color, std::uint8_t>(Color::RED, 1U));
   REQUIRE(std::make_pair(colors[1], color_rgb_container_int[colors[1]]) == std::make_pair<Color, std::uint8_t>(Color::GREEN, 2U));
@@ -145,9 +145,9 @@ TEST_CASE("containers_array") {
   REQUIRE(color_rgb_container.front() == RGB{color_max, 0, 0});
   REQUIRE(color_rgb_container.back() == RGB{0, 0, color_max});
 
-  REQUIRE(std::get<Color::RED>(color_rgb_container) == RGB{color_max, 0, 0});
-  REQUIRE(std::get<Color::GREEN>(color_rgb_container) == RGB{0, color_max, 0});
-  REQUIRE(std::get<Color::BLUE>(color_rgb_container) == RGB{0, 0, color_max});
+  REQUIRE(magic_enum::containers::get<Color::RED>(color_rgb_container) == RGB{color_max, 0, 0});
+  REQUIRE(magic_enum::containers::get<Color::GREEN>(color_rgb_container) == RGB{0, color_max, 0});
+  REQUIRE(magic_enum::containers::get<Color::BLUE>(color_rgb_container) == RGB{0, 0, color_max});
 
   auto iterator = color_rgb_container.begin();
   REQUIRE_FALSE(check_const(iterator));


### PR DESCRIPTION
In `magic_enum` `std::get` is extended https://github.com/Neargye/magic_enum/blob/master/include/magic_enum/magic_enum_containers.hpp#L1130. But с++ documentation states, that "It is undefined behavior to declare a full specialization of any standard library function template." (https://en.cppreference.com/w/cpp/language/extending_std section "Function templates and member functions of templates").

So, `get` is moved to `magic_enum::containers`.

Closes https://github.com/Neargye/magic_enum/issues/315