### PR TITLE
Add support for overriding MAGIC_ENUM_ASSERT

### DIFF
--- a/include/magic_enum/magic_enum.hpp
+++ b/include/magic_enum/magic_enum.hpp
@@ -60,7 +60,7 @@
 
 #if defined(MAGIC_ENUM_NO_ASSERT)
 #  define MAGIC_ENUM_ASSERT(...) static_cast<void>(0)
-#else
+#elif !defined(MAGIC_ENUM_ASSERT)
 #  include <cassert>
 #  define MAGIC_ENUM_ASSERT(...) assert((__VA_ARGS__))
 #endif


### PR DESCRIPTION
Minor change that allows overriding the implementation of `MAGIC_ENUM_ASSERT` via macro, either in `MAGIC_ENUM_CONFIG_FILE` or before including `magic_enum.hpp`