### PR TITLE
CI: hash-pin sensitive workflow and configure dependabot to keep them updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/bzlmod-archive.yml
+++ b/.github/workflows/bzlmod-archive.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - run: git archive -o "${{ format('{0}-{1}.tar.gz', github.event.repository.name, github.event.release.tag_name) }}" HEAD
       - run: gh release upload ${{ github.event.release.tag_name }} *.tar.gz
         env:


### PR DESCRIPTION
Closes #328

As mentioned on the issue, this PR enhances project security by hash-pinning the dependencies that are called under dangerous permissions. Additionally, it enables dependabot to update them automatically.

I configured dependabot in a way that all of version updates will be collapsed in a single PR sent monthly -- this avoids noisy PRs, which is a common concern haha. Regardless of the frequency chosen, for the case of security updates a PR with the fixed version would be sent right away.