### PR TITLE
example_switch.cpp: properly return 0

### DIFF
--- a/example/example_switch.cpp
+++ b/example/example_switch.cpp
@@ -102,4 +102,6 @@ int main() {
   std::cout << magic_enum::enum_switch(switcher3, Color::GREEN, std::make_optional("cica")).value() << std::endl; // prints default: "cica"
   std::cout << magic_enum::enum_switch(switcher3, Color::RED, std::make_optional("cica")).value() << std::endl; // prints: "red result"
   std::cout << magic_enum::enum_switch(switcher3, Color::BLUE, std::make_optional("cica")).has_value() << std::endl; // prints: false
+
+  return 0;
 }


### PR DESCRIPTION
The main function in example_switch.cpp was declared as `int main()` but actually does not return a value - this fixes this by adding `return 0` to the end of the function.