### PR TITLE
Parameterize formatter::format to use with FMT_COMPILE

### DIFF
--- a/include/magic_enum/magic_enum_format.hpp
+++ b/include/magic_enum/magic_enum_format.hpp
@@ -56,7 +56,8 @@ namespace magic_enum::customize {
 
 template <typename E>
 struct std::formatter<E, std::enable_if_t<std::is_enum_v<std::decay_t<E>> && magic_enum::customize::enum_format_enabled<E>(), char>> : std::formatter<std::string_view, char> {
-  auto format(E e, format_context& ctx) const {
+  template <class FormatContext>
+  auto format(E e, FormatContext& ctx) const {
     static_assert(std::is_same_v<char, string_view::value_type>, "formatter requires string_view::value_type type same as char.");
     using D = std::decay_t<E>;
 
@@ -83,7 +84,8 @@ struct std::formatter<E, std::enable_if_t<std::is_enum_v<std::decay_t<E>> && mag
 
 template <typename E>
 struct fmt::formatter<E, std::enable_if_t<std::is_enum_v<std::decay_t<E>> && magic_enum::customize::enum_format_enabled<E>(), char>> : fmt::formatter<std::string_view> {
-  auto format(E e, format_context& ctx) const {
+  template <class FormatContext>
+  auto format(E e, FormatContext& ctx) const {
     static_assert(std::is_same_v<char, string_view::value_type>, "formatter requires string_view::value_type type same as char.");
     using D = std::decay_t<E>;
 


### PR DESCRIPTION
https://github.com/fmtlib/fmt/issues/4059#issuecomment-2214074477

tested by adding fmt library into `make_test` and running the case
```
TEST_CASE("format-fmt") {
  REQUIRE(fmt::format("{}", Color::RED) == "red");
  REQUIRE(fmt::format("{}", Color{0}) == "0");

  REQUIRE(fmt::format(FMT_STRING("{}"), Color::RED) == "red");
  REQUIRE(fmt::format(FMT_STRING("{}"), Color{0}) == "0");

  REQUIRE(fmt::format(FMT_COMPILE("{}"), Color::RED) == "red");
  REQUIRE(fmt::format(FMT_COMPILE("{}"), Color{0}) == "0");
}
```