### PR TITLE
meson: install headers and pkg-config file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,16 @@ magic_enum_dep = declare_dependency(
     compile_args: magic_enum_args,
 )
 
+# install header and pkg-config file
+install_subdir('include/magic_enum', install_dir: get_option('includedir'))
+pkg = import('pkgconfig')
+pkg.generate(
+  name: 'magic_enum',
+  description: 'A library that provides static reflection for enums, work with any enum type without any macro or boilerplate code.',
+  url: 'https://github.com/Neargye/magic_enum',
+  extra_cflags: magic_enum_args,
+)
+
 if get_option('test')
     subdir('test')
 endif


### PR DESCRIPTION
This is useful when embedding `magic_enum` as a subproject in a larger Meson project. Would be super cool if you tag a version with this for us to use :)