### PR TITLE
fix: update `magic_enum.hpp` reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ If you like this project, please consider donating to one of the funds that help
 
 ## Integration
 
-* You should add the required file [magic_enum.hpp](include/magic_enum.hpp), and optionally other headers from [include dir](include/) or [release archive](https://github.com/Neargye/magic_enum/releases/latest). Alternatively, you can build the library with CMake.
+* You should add the required file [magic_enum.hpp](include/magic_enum/magic_enum.hpp), and optionally other headers from [include dir](include/) or [release archive](https://github.com/Neargye/magic_enum/releases/latest). Alternatively, you can build the library with CMake.
 
 * If you are using [vcpkg](https://github.com/Microsoft/vcpkg/) on your project for external dependencies, then you can use the [magic-enum package](https://github.com/microsoft/vcpkg/tree/master/ports/magic-enum).
 


### PR DESCRIPTION
# PR Summary
Small PR - Commit eb867ec9baaabc5b60816861923fdef53972cba2 moved the `magic_enum.hpp` file from `include/` to `include/magic_enum/`. This PR adjusts sources to changes.