### PR TITLE
Support fmt and std::format in C++20 module

### DIFF
--- a/module/magic_enum.cppm
+++ b/module/magic_enum.cppm
@@ -1,6 +1,9 @@
 module;
 
 #include <version>
+#if __has_include(<fmt/base.h>)
+#include <fmt/base.h>
+#endif
 #ifndef MAGIC_ENUM_USE_STD_MODULE
 #include <magic_enum/magic_enum_all.hpp>
 #endif
@@ -72,5 +75,11 @@ namespace containers {
 #if defined(__cpp_lib_format)
 export namespace std {
     using std::formatter;
+}
+#endif
+
+#if defined(FMT_VERSION)
+export namespace fmt {
+    using fmt::formatter;
 }
 #endif

--- a/module/magic_enum.cppm
+++ b/module/magic_enum.cppm
@@ -5,6 +5,9 @@ module;
 #include <fmt/format.h>
 #endif
 #ifndef MAGIC_ENUM_USE_STD_MODULE
+#if defined(__cpp_lib_format)
+#include <format>
+#endif
 #include <magic_enum/magic_enum_all.hpp>
 #endif
 

--- a/module/magic_enum.cppm
+++ b/module/magic_enum.cppm
@@ -1,8 +1,8 @@
 module;
 
 #include <version>
-#if __has_include(<fmt/base.h>)
-#include <fmt/base.h>
+#if __has_include(<fmt/format.h>)
+#include <fmt/format.h>
 #endif
 #ifndef MAGIC_ENUM_USE_STD_MODULE
 #include <magic_enum/magic_enum_all.hpp>


### PR DESCRIPTION
~`<fmt/base.h>` defines `FMT_VERSION`, which is what magic_enum checks for when specializing `fmt::formatter`.~

https://github.com/Neargye/magic_enum/commit/ff6e5dd1c82a0c8cf8f774759933cc0a353fa5f9 removed the `<format>` and `<fmt/format.h>` includes from `magic_enum_format.hpp`.