### PR TITLE
fix: use `inline` instead of `static` for constexpr in header file

### DIFF
--- a/include/magic_enum/magic_enum_containers.hpp
+++ b/include/magic_enum/magic_enum_containers.hpp
@@ -52,10 +52,10 @@ namespace magic_enum::containers {
 namespace detail {
 
 template <typename T, typename = void>
-static constexpr bool is_transparent_v{};
+inline constexpr bool is_transparent_v{};
 
 template <typename T>
-static constexpr bool is_transparent_v<T, std::void_t<typename T::is_transparent>>{true};
+inline constexpr bool is_transparent_v<T, std::void_t<typename T::is_transparent>>{true};
 
 template <typename Eq = std::equal_to<>, typename T1, typename T2>
 constexpr bool equal(T1&& t1, T2&& t2, Eq&& eq = {}) {


### PR DESCRIPTION
This error is related to recently implemented [P1815](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p1815r2) in GCC 15.

I understand that `is_transparent` is TU(translation-unit)-local and therefore has internal linkage as it's declared as `static`.  If we want a `constexpr` variable declared in a header to have a constant address - which I assume is the intent here with `static` - in a header file it should use `inline` instead (see reference: https://isocpp.org/blog/2018/05/quick-q-use-of-constexpr-in-header-file). 

<details>

<summary>Build result before the fix</summary>

```
FAILED: CMakeFiles/magic_enum_module.dir/module/magic_enum.cppm.o CMakeFiles/magic_enum_module.dir/magic_enum.gcm 
/usr/bin/c++  -I/mnt/d/dev/libs/tools/cpp/magic_enum/include -g -std=gnu++20 -fdiagnostics-color=always -MD -MT CMakeFiles/magic_enum_module.dir/module/magic_enum.cppm.o -MF CMakeFiles/magic_enum_module.dir/module/magic_enum.cppm.o.d -fmodules-ts -fmodule-mapper=CMakeFiles/magic_enum_module.dir/module/magic_enum.cppm.o.modmap -MD -fdeps-format=p1689r5 -x c++ -o CMakeFiles/magic_enum_module.dir/module/magic_enum.cppm.o -c /mnt/d/dev/libs/tools/cpp/magic_enum/module/magic_enum.cppm
In file included from /opt/gcc-dev/include/c++/15.0.1/concepts:48,
                 from /opt/gcc-dev/include/c++/15.0.1/compare:42,
                 from /opt/gcc-dev/include/c++/15.0.1/array:40,
                 from /mnt/d/dev/libs/tools/cpp/magic_enum/include/magic_enum/magic_enum.hpp:40,
                 from /mnt/d/dev/libs/tools/cpp/magic_enum/include/magic_enum/magic_enum_all.hpp:35,
                 from /mnt/d/dev/libs/tools/cpp/magic_enum/module/magic_enum.cppm:5:
/opt/gcc-dev/include/c++/15.0.1/type_traits:2836:11: error: ‘using std::enable_if_t = typename std::enable_if<is_transparent_v<KC, void>, long unsigned int>::type’ exposes TU-local entity ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’
 2836 |     using enable_if_t = typename enable_if<_Cond, _Tp>::type;
      |           ^~~~~~~~~~~
In file included from /mnt/d/dev/libs/tools/cpp/magic_enum/include/magic_enum/magic_enum_all.hpp:36:
/mnt/d/dev/libs/tools/cpp/magic_enum/include/magic_enum/magic_enum_containers.hpp:55:23: note: ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’ declared with internal linkage
   55 | static constexpr bool is_transparent_v{};
      |                       ^~~~~~~~~~~~~~~~
/opt/gcc-dev/include/c++/15.0.1/type_traits:133:12: error: ‘struct std::enable_if<is_transparent_v<KC, void>, magic_enum::containers::detail::FilteredIterator<const magic_enum::containers::set<E, Cmp>*, const E*, magic_enum::containers::set<E, Cmp>::Getter, magic_enum::containers::set<E, Cmp>::Predicate> >’ exposes TU-local entity ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’
  133 |     struct enable_if
      |            ^~~~~~~~~
/mnt/d/dev/libs/tools/cpp/magic_enum/include/magic_enum/magic_enum_containers.hpp:55:23: note: ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’ declared with internal linkage
   55 | static constexpr bool is_transparent_v{};
      |                       ^~~~~~~~~~~~~~~~
/opt/gcc-dev/include/c++/15.0.1/type_traits:2836:11: error: ‘using std::enable_if_t = typename std::enable_if<is_transparent_v<KC, void>, magic_enum::containers::detail::FilteredIterator<const magic_enum::containers::set<E, Cmp>*, const E*, magic_enum::containers::set<E, Cmp>::Getter, magic_enum::containers::set<E, Cmp>::Predicate> >::type’ exposes TU-local entity ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’
 2836 |     using enable_if_t = typename enable_if<_Cond, _Tp>::type;
      |           ^~~~~~~~~~~
/mnt/d/dev/libs/tools/cpp/magic_enum/include/magic_enum/magic_enum_containers.hpp:55:23: note: ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’ declared with internal linkage
   55 | static constexpr bool is_transparent_v{};
      |                       ^~~~~~~~~~~~~~~~
/opt/gcc-dev/include/c++/15.0.1/type_traits:2836:11: error: ‘using std::enable_if_t = typename std::enable_if<is_transparent_v<KC, void>, bool>::type’ exposes TU-local entity ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’
 2836 |     using enable_if_t = typename enable_if<_Cond, _Tp>::type;
      |           ^~~~~~~~~~~
/mnt/d/dev/libs/tools/cpp/magic_enum/include/magic_enum/magic_enum_containers.hpp:55:23: note: ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’ declared with internal linkage
   55 | static constexpr bool is_transparent_v{};
      |                       ^~~~~~~~~~~~~~~~
/opt/gcc-dev/include/c++/15.0.1/type_traits:133:12: error: ‘struct std::enable_if<is_transparent_v<KC, void>, std::pair<magic_enum::containers::detail::FilteredIterator<const magic_enum::containers::set<E, Cmp>*, const E*, magic_enum::containers::set<E, Cmp>::Getter, magic_enum::containers::set<E, Cmp>::Predicate>, magic_enum::containers::detail::FilteredIterator<const magic_enum::containers::set<E, Cmp>*, const E*, magic_enum::containers::set<E, Cmp>::Getter, magic_enum::containers::set<E, Cmp>::Predicate> > >’ exposes TU-local entity ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’
  133 |     struct enable_if
      |            ^~~~~~~~~
/mnt/d/dev/libs/tools/cpp/magic_enum/include/magic_enum/magic_enum_containers.hpp:55:23: note: ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’ declared with internal linkage
   55 | static constexpr bool is_transparent_v{};
      |                       ^~~~~~~~~~~~~~~~
/opt/gcc-dev/include/c++/15.0.1/type_traits:133:12: error: ‘struct std::enable_if<is_transparent_v<KC, void>, long unsigned int>’ exposes TU-local entity ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’
  133 |     struct enable_if
      |            ^~~~~~~~~
/mnt/d/dev/libs/tools/cpp/magic_enum/include/magic_enum/magic_enum_containers.hpp:55:23: note: ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’ declared with internal linkage
   55 | static constexpr bool is_transparent_v{};
      |                       ^~~~~~~~~~~~~~~~
/opt/gcc-dev/include/c++/15.0.1/type_traits:133:12: error: ‘struct std::enable_if<is_transparent_v<KC, void>, bool>’ exposes TU-local entity ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’
  133 |     struct enable_if
      |            ^~~~~~~~~
/mnt/d/dev/libs/tools/cpp/magic_enum/include/magic_enum/magic_enum_containers.hpp:55:23: note: ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’ declared with internal linkage
   55 | static constexpr bool is_transparent_v{};
      |                       ^~~~~~~~~~~~~~~~
/opt/gcc-dev/include/c++/15.0.1/type_traits:2836:11: error: ‘using std::enable_if_t = typename std::enable_if<is_transparent_v<KC, void>, std::pair<magic_enum::containers::detail::FilteredIterator<const magic_enum::containers::set<E, Cmp>*, const E*, magic_enum::containers::set<E, Cmp>::Getter, magic_enum::containers::set<E, Cmp>::Predicate>, magic_enum::containers::detail::FilteredIterator<const magic_enum::containers::set<E, Cmp>*, const E*, magic_enum::containers::set<E, Cmp>::Getter, magic_enum::containers::set<E, Cmp>::Predicate> > >::type’ exposes TU-local entity ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’
 2836 |     using enable_if_t = typename enable_if<_Cond, _Tp>::type;
      |           ^~~~~~~~~~~
/mnt/d/dev/libs/tools/cpp/magic_enum/include/magic_enum/magic_enum_containers.hpp:55:23: note: ‘template<class T, class> constexpr const bool magic_enum::containers::detail::is_transparent_v<T, <template-parameter-1-2> >’ declared with internal linkage
   55 | static constexpr bool is_transparent_v{};
      |                       ^~~~~~~~~~~~~~~~
```

</details>

To reproduce the issue - using cmake 3.31.5 and GCC development version 15.0.1 20250205  - I had to create a module target as follows (added to the end of the CMakeLists.txt file). I could not reproduce it by building the tests.

```cmake
set(MAGIC_ENUM_MODULE_TGT ${PROJECT_NAME}_module)
add_library(${MAGIC_ENUM_MODULE_TGT})
target_compile_features(${MAGIC_ENUM_MODULE_TGT} PUBLIC cxx_std_20)
target_sources(${MAGIC_ENUM_MODULE_TGT}
  PUBLIC FILE_SET CXX_MODULES FILES module/magic_enum.cppm
)
target_link_libraries(${MAGIC_ENUM_MODULE_TGT} PRIVATE ${PROJECT_NAME})
```

Working branch including the CMakeLists.txt change above is [here](https://github.com/tkhyn/magic_enum/tree/tu-local-entity-issue-gcc-15)

Thanks in advance for looking into this.