### PR TITLE
Fix __FUNCSIG__ parsing on x86 by explicitly declaring the calling convention

### DIFF
--- a/include/magic_enum/magic_enum.hpp
+++ b/include/magic_enum/magic_enum.hpp
@@ -418,7 +418,7 @@ template <typename T>
 inline constexpr bool is_enum_v = std::is_enum_v<T> && std::is_same_v<T, std::decay_t<T>>;
 
 template <typename E>
-constexpr auto n() noexcept {
+constexpr auto __cdecl n() noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::n requires enum type.");
 
   if constexpr (supported<E>::value) {
@@ -494,7 +494,7 @@ template <typename E>
 inline constexpr auto type_name_v = type_name<E>();
 
 template <auto V>
-constexpr auto n() noexcept {
+constexpr auto __cdecl n() noexcept {
   static_assert(is_enum_v<decltype(V)>, "magic_enum::detail::n requires enum type.");
 
   if constexpr (supported<decltype(V)>::value) {
@@ -566,7 +566,7 @@ constexpr auto n() noexcept {
 
 #if defined(MAGIC_ENUM_VS_2017_WORKAROUND)
 template <typename E, E V>
-constexpr auto n() noexcept {
+constexpr auto __cdecl n() noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::n requires enum type.");
 
 #  if defined(MAGIC_ENUM_GET_ENUM_NAME_BUILTIN)

--- a/include/magic_enum/magic_enum.hpp
+++ b/include/magic_enum/magic_enum.hpp
@@ -98,6 +98,14 @@
 #  define MAGIC_ENUM_SUPPORTED_ALIASES 1
 #endif
 
+// Specify the calling convention for compilers that need it in order to get reliable mangled names under different
+// compiler flags. In particular, MSVC allows changing the default calling convention on x86.
+#if defined(__clang__) || defined(__GNUC__)
+#define MAGIC_ENUM_CALLING_CONVENTION
+#elif defined(_MSC_VER)
+#define MAGIC_ENUM_CALLING_CONVENTION __cdecl
+#endif
+
 // Enum value must be greater or equals than MAGIC_ENUM_RANGE_MIN. By default MAGIC_ENUM_RANGE_MIN = -128.
 // If need another min range for all enum types by default, redefine the macro MAGIC_ENUM_RANGE_MIN.
 #if !defined(MAGIC_ENUM_RANGE_MIN)
@@ -418,7 +426,7 @@ template <typename T>
 inline constexpr bool is_enum_v = std::is_enum_v<T> && std::is_same_v<T, std::decay_t<T>>;
 
 template <typename E>
-constexpr auto __cdecl n() noexcept {
+constexpr auto MAGIC_ENUM_CALLING_CONVENTION n() noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::n requires enum type.");
 
   if constexpr (supported<E>::value) {
@@ -494,7 +502,7 @@ template <typename E>
 inline constexpr auto type_name_v = type_name<E>();
 
 template <auto V>
-constexpr auto __cdecl n() noexcept {
+constexpr auto MAGIC_ENUM_CALLING_CONVENTION n() noexcept {
   static_assert(is_enum_v<decltype(V)>, "magic_enum::detail::n requires enum type.");
 
   if constexpr (supported<decltype(V)>::value) {
@@ -566,7 +574,7 @@ constexpr auto __cdecl n() noexcept {
 
 #if defined(MAGIC_ENUM_VS_2017_WORKAROUND)
 template <typename E, E V>
-constexpr auto __cdecl n() noexcept {
+constexpr auto MAGIC_ENUM_CALLING_CONVENTION n() noexcept {
   static_assert(is_enum_v<E>, "magic_enum::detail::n requires enum type.");
 
 #  if defined(MAGIC_ENUM_GET_ENUM_NAME_BUILTIN)


### PR DESCRIPTION
This change fixes parsing of enum value names on MSVC x86, by explicitly specifying the calling convention as __cdecl. Calling conventions aren't really a thing on x64, but on x86 the default calling convention can be changed w/ compiler flags. Since the parsing of the enum out of __FUNCSIG__ relies on the precise format of this string, the calling convention needs to be __cdecl, or else the location of the ( )s is different than expected.

To fix my usage of magic_enum, I needed to add __cdecl to the instance on line 497, but I suspect that the other two functions that similarly parse these magic symbols also need this treatment to function properly on x86 under all possible default calling conventions, so I went ahead and fixed them as well.