### PR TITLE
fix: warnings about included file in module purview in MSVC

### DIFF
--- a/module/magic_enum.cppm
+++ b/module/magic_enum.cppm
@@ -11,10 +11,21 @@ export module magic_enum;
 import std;
 
 extern "C++" {
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winclude-angled-in-module-purview"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 5244)
+#endif
+
 #include <magic_enum/magic_enum_all.hpp>
+
+#ifdef __clang__
 #pragma clang diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 }
 #endif
 


### PR DESCRIPTION
fixes warnings in MSVC about unknown pragma clang and suppresses 5244 about including file in purview of module