### PR TITLE
Fix GIT_TAG for CMake's `CPAMAddPackage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ If you like this project, please consider donating to one of the funds that help
   CPMAddPackage(
       NAME magic_enum
       GITHUB_REPOSITORY Neargye/magic_enum
-      GIT_TAG x.y.z # Where `x.y.z` is the release version you want to use.
+      GIT_TAG vx.y.z # Where `x.y.z` is the release version you want to use.
   )
   ```
 


### PR DESCRIPTION
```cmake
CPMAddPackage(
    NAME magic_enum
    GITHUB_REPOSITORY Neargye/magic_enum
    GIT_TAG 0.9.7
)
```
Without the "v" it doesn't download:

```
-- CPM: Adding package magic_enum@0.9.7 (0.9.7)
[1/9] Creating directories for 'magic_enum-populate'
[1/9] Performing download step (git clone) for 'magic_enum-populate'
Cloning into 'magic_enum-src'...
fatal: invalid reference: 0.9.7
CMake Error at magic_enum-subbuild/magic_enum-populate-prefix/tmp/magic_enum-populate-gitclone.cmake:61 (message):
  Failed to checkout tag: '0.9.7'
```

Best