### PR TITLE
Fix link error

### DIFF
--- a/include/magic_enum/magic_enum.hpp
+++ b/include/magic_enum/magic_enum.hpp
@@ -203,7 +203,7 @@ struct adl_info_holder {
     constexpr static adl_info_holder<IsFlags,Min,Max,prefix_len> prefix() { return {};}
 };
 
-adl_info_holder<> adl_info()
+inline adl_info_holder<> adl_info()
 {
      return {};
 }


### PR DESCRIPTION
Link error with duplicated symbol without "inline"