### PR TITLE
Replace test option with not building tests by default

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,6 +27,4 @@ pkg.generate(
   extra_cflags: magic_enum_args,
 )
 
-if get_option('test')
-    subdir('test')
-endif
+subdir('test')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,11 +1,4 @@
 option(
-    'test',
-    type : 'boolean',
-    value : true,
-    description : 'Build and run tests'
-)
-
-option(
     'hash',
     type : 'boolean',
     value : false,

--- a/test/meson.build
+++ b/test/meson.build
@@ -10,6 +10,7 @@ foreach test_name, test_src : test_files
         test_name.underscorify(),
         test_src,
 
+        build_by_default: false,
         dependencies: [magic_enum_dep, catch2_dep],
     )
 


### PR DESCRIPTION
Following a discussion [here](https://github.com/mesonbuild/wrapdb/pull/2427), it seems like it would be perhaps more standard to not build tests by default rather than using a feature flag. This way they are not built by default by projects using this as a subproject, but will still be build automatically when running `meson test` in this projects and projects depending upon it. What do you think?