### PR TITLE
fix: add missing return type in FatalConditionHandler (catch.hpp) to fix compile error

### DIFF
--- a/test/3rdparty/Catch2/include/catch2/catch.hpp
+++ b/test/3rdparty/Catch2/include/catch2/catch.hpp
@@ -10751,8 +10751,8 @@ namespace Catch {
 
     // If neither SEH nor signal handling is required, the handler impls
     // do not have to do anything, and can be empty.
-    FatalConditionHandler::engage_platform() {}
-    FatalConditionHandler::disengage_platform() {}
+    void FatalConditionHandler::engage_platform() {}
+    void FatalConditionHandler::disengage_platform() {}
     FatalConditionHandler::FatalConditionHandler() = default;
     FatalConditionHandler::~FatalConditionHandler() = default;
 


### PR DESCRIPTION
The FatalConditionHandler class in Catch2's vendored catch.hpp
was missing return types for its member functions engage_platform()
and disengage_platform(). This caused compilation errors on compilers
that enforce standard C++ rules.

This patch adds the missing 'void' return type to these functions,
fixing the compile error without changing any test logic.
