### PR TITLE
add rules_cc bazel dependency

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
 licenses(["notice"])
 
 exports_files(["LICENSE"])

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,3 +3,5 @@ module(
     version = "0.9.7",
     compatibility_level = 0,
 )
+
+bazel_dep(name = "rules_cc", version = "0.2.14")

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_test", "cc_library")
+
 _TESTS = [
     "test",
     "test_flags",

--- a/test/MODULE.bazel
+++ b/test/MODULE.bazel
@@ -1,6 +1,9 @@
 module(name = "magic_enum_tests")
 
 bazel_dep(name = "magic_enum")
-local_path_override(module_name = "magic_enum", path = "..")
+local_path_override(
+    module_name = "magic_enum",
+    path = "..",
+)
 
-bazel_dep(name = "rules_cc", version = "0.0.8")
+bazel_dep(name = "rules_cc", version = "0.2.14")


### PR DESCRIPTION
In bazel 9 all cc_* rules must be loaded from `rules_cc` or else there will be a build error.
