### PR TITLE
Fix redefinition errors when compiling as module (regression fix)

### DIFF
--- a/include/magic_enum/magic_enum_format.hpp
+++ b/include/magic_enum/magic_enum_format.hpp
@@ -59,7 +59,9 @@ std::string format_as(E e) {
 
 #if defined(__cpp_lib_format)
 
+#ifndef MAGIC_ENUM_USE_STD_MODULE
 #include <format>
+#endif
 
 template <typename E>
 struct std::formatter<E, std::enable_if_t<std::is_enum_v<std::decay_t<E>>, char>> : std::formatter<std::string_view, char> {


### PR DESCRIPTION
Hello,

This trivial pull request fixes type redefinition errors when compiling magic_enum as a module while the preprocessor variable MAGIC_ENUM_USE_STD_MODULE is defined.

### Issue

Compiling magic_enum modules with the preprocessor variable MAGIC_ENUM_USE_STD_MODULE defined causes type redefinition errors in the Microsoft Compiler. This occurs because the <format> header is #include'd on line 62 of magic_enum_format.hpp. This line should be wrapped in `#ifndef MAGIC_ENUM_USE_STD_MODULE` / `#endif`.

This regression was introduced in commit a0db691, on 2025-11-21.

### Steps to Reproduce

1. Include current development version (master / https://github.com/Neargye/magic_enum/tree/2e6e8bfff361c2c40990426c462b44af6c27820b) of magic_enum in a project.
2. Enable modules.
3. Define preprocessor variable MAGIC_ENUM_USE_STD_MODULE.
4. Compile and receive many type redefinition errors.

### Fix

On line 62 of magic_enum_format.hpp, change

```c++
#include <format>
```

to

```c++
#ifndef MAGIC_ENUM_USE_STD_MODULE  
#include <format>  
#endif
```

### Environment

* Compiler: Microsoft C/C++ Optimizing Compiler Version 19.50.35719
* Windows 11 Version 10.0.26200