### PR TITLE
fix / added case_insensitive to module file

### DIFF
--- a/module/magic_enum.cppm
+++ b/module/magic_enum.cppm
@@ -84,6 +84,7 @@ namespace containers {
     using magic_enum::is_scoped_enum_v;
     using magic_enum::underlying_type;
     using magic_enum::underlying_type_t;
+    using magic_enum::case_insensitive;
 }
 
 #if defined(__cpp_lib_format)


### PR DESCRIPTION
When using magic enum via the C++20 module, `magic_enum::case_insensitive` cannot be resolved because it is missing in the module file. There might be more symbols that are missing. I did not check throughoutly.