### PR TITLE
Install legacy magic_enum.hpp compatibility shim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,12 @@ if(MAGIC_ENUM_OPT_INSTALL)
     )
   endif()
 
+  # Compatibility shim for `#include <magic_enum.hpp>` (pre-0.9.7 layout).
+  install(
+    FILES "${PROJECT_SOURCE_DIR}/include/magic_enum.hpp"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  )
+
   set(MAGIC_ENUM_EXPORT_TARGETS "${PROJECT_NAME}")
   if(MAGIC_ENUM_USE_MODULES)
     install(

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Header-only C++17 library provides static reflection for enums, work with any en
   }
   ```
 
+  Installed packages also provide a compatibility shim so older code can keep using
+  `#include <magic_enum.hpp>`. Prefer `#include <magic_enum/magic_enum.hpp>` in new code.
+
 * Enum value to string
 
   ```cpp

--- a/include/magic_enum.hpp
+++ b/include/magic_enum.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+// Compatibility shim for pre-0.9.7 `#include <magic_enum.hpp>` includes.
+// Prefer `#include <magic_enum/magic_enum.hpp>` for new code.
+#include "magic_enum/magic_enum.hpp"


### PR DESCRIPTION
Fixes #419

## Summary

- Install a compatibility shim header at `include/magic_enum.hpp` that forwards to `magic_enum/magic_enum.hpp`.
- Document the legacy include path for users upgrading from pre-0.9.7 layouts.

## Test plan

- [ ] `cmake --install` and verify both `include/magic_enum/magic_enum.hpp` and `include/magic_enum.hpp` exist.
- [ ] Compile a consumer with `#include <magic_enum.hpp>` against the installed package.
