### PR TITLE
feat: public enum_min()/enum_max() helpers (#462)

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -4,6 +4,7 @@
 * [`enum_value` returns enum value at specified index.](#enum_value)
 * [`enum_values` returns enum value sequence.](#enum_values)
 * [`enum_count` returns number of enum values.](#enum_count)
+* [`enum_min` and `enum_max` return min/max reflected enum values.](#enum_min-and-enum_max)
 * [`enum_integer` and `enum_underlying` return underlying enum value.](#enum_integer-and-enum_underlying)
 * [`enum_name` returns name from enum value.](#enum_name)
 * [`enum_names` returns enum name sequence.](#enum_names)
@@ -179,6 +180,31 @@ constexpr size_t enum_count() noexcept;
   ```cpp
   constexpr auto color_count = magic_enum::enum_count<Color>();
   // color_count -> 3
+  ```
+
+## `enum_min` and `enum_max`
+
+```cpp
+template <typename E>
+constexpr E enum_min() noexcept;
+
+template <typename E>
+constexpr E enum_max() noexcept;
+```
+
+* Defined in header `<magic_enum/magic_enum.hpp>`
+
+* Returns the minimum or maximum reflected enum value (first/last in `enum_values<E>()` order).
+* Optional subtype parameter (e.g. `as_flags<>` / `as_common<>`) matches other reflection APIs.
+* Underlying integer is available via `enum_underlying(enum_min<E>())` / `enum_underlying(enum_max<E>())`.
+
+* Examples
+
+  ```cpp
+  constexpr auto color_min = magic_enum::enum_min<Color>();
+  // color_min -> Color::RED
+  constexpr auto color_max = magic_enum::enum_max<Color>();
+  // color_max -> Color::BLUE
   ```
 
 ## `enum_integer` and `enum_underlying`

--- a/include/magic_enum/magic_enum.hpp
+++ b/include/magic_enum/magic_enum.hpp
@@ -1301,6 +1301,24 @@ template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
   return detail::values_v<D, S>;
 }
 
+// Returns the minimum (first) reflected enum value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_min() noexcept -> detail::enable_if_t<E, std::decay_t<E>> {
+  using D = std::decay_t<E>;
+  static_assert(detail::count_v<D, S> > 0, "magic_enum::enum_min requires at least one reflected enum value.");
+
+  return detail::values_v<D, S>.front();
+}
+
+// Returns the maximum (last) reflected enum value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_max() noexcept -> detail::enable_if_t<E, std::decay_t<E>> {
+  using D = std::decay_t<E>;
+  static_assert(detail::count_v<D, S> > 0, "magic_enum::enum_max requires at least one reflected enum value.");
+
+  return detail::values_v<D, S>.back();
+}
+
 // Returns integer value from enum value.
 template <typename E>
 [[nodiscard]] constexpr auto enum_integer(E value) noexcept -> underlying_type_t<E> {

--- a/module/magic_enum.cppm
+++ b/module/magic_enum.cppm
@@ -159,6 +159,8 @@ using magic_enum::enum_cast;
 using magic_enum::enum_value;
 using magic_enum::enum_values;
 using magic_enum::enum_count;
+using magic_enum::enum_min;
+using magic_enum::enum_max;
 using magic_enum::enum_integer;
 using magic_enum::enum_underlying;
 using magic_enum::enum_names;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -516,6 +516,54 @@ TEST_CASE("enum_values") {
 
 }
 
+TEST_CASE("enum_min") {
+  constexpr auto s1 = enum_min<Color&>();
+  REQUIRE(s1 == Color::RED);
+  REQUIRE(std::is_same_v<decltype(s1), Color>);
+
+  constexpr auto s2 = enum_min<Numbers>();
+  REQUIRE(s2 == Numbers::one);
+
+  constexpr auto s3 = enum_min<const Directions>();
+  REQUIRE(s3 == Left);
+
+  constexpr auto s4 = enum_min<number>();
+  REQUIRE(s4 == number::one);
+
+  constexpr auto s5 = enum_min<Binary>();
+  REQUIRE(s5 == Binary::ONE);
+
+  constexpr auto s6 = enum_min<MaxUsedAsInvalid>();
+  REQUIRE(s6 == MaxUsedAsInvalid::ONE);
+
+  REQUIRE(enum_underlying(enum_min<Color>()) == magic_enum::detail::min_v<Color, as_common<>>);
+  REQUIRE(enum_min<Color, as_common<>>() == Color::RED);
+}
+
+TEST_CASE("enum_max") {
+  constexpr auto s1 = enum_max<Color&>();
+  REQUIRE(s1 == Color::BLUE);
+  REQUIRE(std::is_same_v<decltype(s1), Color>);
+
+  constexpr auto s2 = enum_max<Numbers>();
+  REQUIRE(s2 == Numbers::three);
+
+  constexpr auto s3 = enum_max<const Directions>();
+  REQUIRE(s3 == Right);
+
+  constexpr auto s4 = enum_max<number>();
+  REQUIRE(s4 == number::three);
+
+  constexpr auto s5 = enum_max<Binary>();
+  REQUIRE(s5 == Binary::TWO);
+
+  constexpr auto s6 = enum_max<MaxUsedAsInvalid>();
+  REQUIRE(s6 == MaxUsedAsInvalid::TWO);
+
+  REQUIRE(enum_underlying(enum_max<Color>()) == magic_enum::detail::max_v<Color, as_common<>>);
+  REQUIRE(enum_max<Color, as_common<>>() == Color::BLUE);
+}
+
 TEST_CASE("enum_count") {
   constexpr auto s1 = enum_count<Color&>();
   REQUIRE(s1 == 3);

--- a/test/test_module.cpp
+++ b/test/test_module.cpp
@@ -48,6 +48,8 @@ using magic_enum::enum_cast;
 using magic_enum::enum_constant;
 using magic_enum::enum_contains;
 using magic_enum::enum_count;
+using magic_enum::enum_max;
+using magic_enum::enum_min;
 using magic_enum::enum_entries;
 using magic_enum::enum_flags_cast;
 using magic_enum::enum_flags_contains;


### PR DESCRIPTION
## Summary
Adds public `magic_enum::enum_min()` / `enum_max()` helpers (#462) so callers do not need `detail::min_v` / `detail::max_v`.

## Test plan
- [ ] `enum_min<Color>()` / `enum_max<Color>()` return expected enumerators
- [ ] Existing tests still pass

Closes #462
